### PR TITLE
Add indexing endpoint

### DIFF
--- a/www/docs/indexing-apis/indexing.md
+++ b/www/docs/indexing-apis/indexing.md
@@ -17,6 +17,9 @@ to do that.
 
 The full definition of the gRPC interface is covered below.
 
+### Index Endpoint
+The indexing endpoint is `indexing.vectara.io`.
+
 ### Service
 
 The indexing service operates in two modes: _incremental_ and _batch_. In


### PR DESCRIPTION
When I tried to use RPC call to index my text, I didn't know what is the indexing endpoint. I searched it on the portal and found nothing and then I searched your github source code to get the answer. I think it will be more convenient and user-friendly if you can put the endpoint on the document page.

Signed-off-by: Jean.T <yt2101@nyu.edu>