### PR TITLE
Update filter metadata docs

### DIFF
--- a/www/docs/search-apis/exact-boolean-text-matches.md
+++ b/www/docs/search-apis/exact-boolean-text-matches.md
@@ -20,8 +20,8 @@ By default, the exact and Boolean text matching is disabled and only neural
 retrieval is used.  You can enable the feature by specifying a value,
 `lambda`, at query time.  This value can range from `0` to `1` (inclusive).
 
-The default value of `lambda` is `0`, and thus turning off exact and Boolean
-text matching.
+The default value of `lambda` is `0`, thus turning off exact and Boolean text
+matching.
 
 A value of `1` would turn off _neural_ retrieval instead, relying _only_ on
 Boolean and exact text matching.  This can be useful if you're trying to

--- a/www/docs/search-apis/exact-boolean-text-matches.md
+++ b/www/docs/search-apis/exact-boolean-text-matches.md
@@ -1,0 +1,49 @@
+---
+id: lexical-matching
+title: Exact and Boolean Text Matching
+sidebar_label: Exact and Boolean Text Matching
+---
+
+Vecata supports the ability to incorporate partial/exact/Boolean matching in
+search results and even to blend them with the neural model in what's called
+a "hybrid" retrieval model.
+
+For example, you can use this in Vectara to:
+- Allow Vectara to include exact keyword matches for occasions where a search
+term was absent from Vectara's training data (e.g. product SKUs)
+- Turn off neural retrieval entirely, and instead use exact term matching
+- Incorporate typical keyword modifiers like a `NOT` function, exact phrase
+matching, and wildcard prefixes of terms
+
+# Enabling Exact and Boolean Text Matching
+By default, the exact and Boolean text matching is disabled and only neural
+retrieval is used.  You can enable the feature by specifying a value,
+`lambda`, at query time.  This value can range from `0` to `1` (inclusive).
+
+The default value of `lambda` is `0`, and thus turning off exact and Boolean
+text matching.
+
+A value of `1` would turn off _neural_ retrieval instead, relying _only_ on
+Boolean and exact text matching.  This can be useful if you're trying to
+evaluate how a keyword system like one based on Elasticsearch or Solr may
+compare to Vectara.
+
+Vectara supports values in between as well, which tells Vectara to try to
+consider _both_ neural _and_ Boolean and exact text matching and then to blend
+the scores of the results of the two different scoring models.  Users often see
+best results by setting this value somewhere between 0.01 and 0.1, and we
+typically recommend users start experimentation with a value of 0.025.
+
+# Syntax
+When interpreting query strings, Vectara treats the following syntax specially.
+
+Words that are quoted must match exactly in that order. So, for example, the
+query "blue shoes" must match the word blue followed immediately by shoes.
+
+A word fragment suffixed with a "*" is treated as a prefix match, meaning that
+it matches any word of which it is a prefix. For example, Miss* matches
+Mississippi.
+
+Words prefixed with a "-" sign are excluded from the results. So, to extend the
+previous example, -Mississippi would exclude results referencing the Magnolia
+State. While -Miss* would exclude references to both Mississippi and Missouri.

--- a/www/docs/search-apis/sql/built_in_filterable_metadata.md
+++ b/www/docs/search-apis/sql/built_in_filterable_metadata.md
@@ -5,10 +5,10 @@ title: Default Filterable Metadata
 
 import {Config} from '../../definitions.md';
 
-A few pieces of metadata that are filterable out of the box, as they're very
+A few pieces of metadata are filterable out of the box, as they're very
 useful in a variety of situations.  This page describes these.
 
-Note tha tyou can set up additional fields to filter on by setting up
+Note that you can set up additional fields to filter on by setting up
 [filter attributes](/docs/admin-apis/create-corpus#filter-attribute) on a
 corpus.
 

--- a/www/docs/search-apis/sql/built_in_filterable_metadata.md
+++ b/www/docs/search-apis/sql/built_in_filterable_metadata.md
@@ -1,0 +1,36 @@
+---
+id: ootb-filters
+title: Default Filterable Metadata
+---
+
+import {Config} from '../../definitions.md';
+
+A few pieces of metadata that are filterable out of the box, as they're very
+useful in a variety of situations.  This page describes these.
+
+Note tha tyou can set up additional fields to filter on by setting up
+[filter attributes](/docs/admin-apis/create-corpus#filter-attribute) on a
+corpus.
+
+## part.lang
+Each section of a document is evaluated for its language at index time and the
+`part.lang` field is added with a 3-character lower-case language code
+([ISO 639-2](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes)).  For
+example, if the section was detected as English, then `part.lang` would contain
+`eng` and if it was detected as German, than `part.lang` would contain `deu`.
+
+Valid filter expressions for this would be something like:
+* `part.lang = 'eng'`
+* `part.lang = 'deu'`
+* `part.lang = 'eng' OR part.lang = 'deu'`
+
+## part.is_title
+When adding content, <Config v="names.product"/> will add a special Boolean
+field to indicate whether the field is a title field or not.  This is useful
+for a few different cases depending on how you model your data.  For example,
+Some users want to only match on a title field or never match on a title field,
+in which case this field can be used to filter.
+
+To filter for title fields only, you can use: `part.is_title = true` and
+conversely `part.is_title = false` will return only non-title sections.
+

--- a/www/docs/search-apis/sql/data_types.md
+++ b/www/docs/search-apis/sql/data_types.md
@@ -8,6 +8,7 @@ title: Data Types
 | Integer      | The value is a signed integer up to eight bytes in length.         |
 | Real (Float) | The value is a floating point number corresponding to a Java double, and is of [IEEE 754 float64 format][1]. |
 | Text         | The value is UTF-8 text.                                           |
+| Boolean      | The value is Boolean                                               |
 | Null         | If metadata is not present, its absence is indicated by NULL.      |
 
 [1]: https://en.wikipedia.org/wiki/Double-precision_floating-point_format

--- a/www/docs/search-apis/sql/overview.md
+++ b/www/docs/search-apis/sql/overview.md
@@ -18,7 +18,7 @@ scopes are `doc.` and `part.`, for document and part-level metadata,
 respectively.
 
 To learn more about setting up metadata so that it can be filtered, have a look
-at the [filter attribute][4] section of the 
+at the [filter attribute][4] section of the corpus creation documentation.
 
 The expression below selects customer reviews in German with better than a
 3-star rating. Note that while there is a single rating for the entire document,
@@ -47,4 +47,4 @@ page.
 [1]: http://www.contrib.andrew.cmu.edu/~shadow/sql/sql1992.txt
 [2]: /docs/search-apis/sql/func-opr
 [3]: https://en.wikipedia.org/wiki/Unix_time
-[4]: https://docs.vectara.com/docs/admin-apis/create-corpus#filter-attribute
+[4]: /docs/admin-apis/create-corpus#filter-attribute

--- a/www/docs/search-apis/sql/overview.md
+++ b/www/docs/search-apis/sql/overview.md
@@ -8,7 +8,7 @@ import {Config} from '../../definitions.md';
 Filter expressions are attached to queries, or, more formally, to its corpus
 keys, and serve to restrict the search to only the part of the corpus that 
 matches the expression. In both form and function, they are a simpler version
-of a where clause's *search condition* in [ANSI SQL, see §7.6][1].
+of a `WHERE` clause's *search condition* in [ANSI SQL, see §7.6][1].
 
 An expression operates on the metadata attached to documents that are indexed
 in <Config v="names.product"/>. Because this metadata can be associated to
@@ -16,6 +16,9 @@ either the entire document, or to specific parts within it, the *scope* must
 be explicitly specified for every metadata reference in the expression. Valid
 scopes are `doc.` and `part.`, for document and part-level metadata,
 respectively.
+
+To learn more about setting up metadata so that it can be filtered, have a look
+at the [filter attribute][4] section of the 
 
 The expression below selects customer reviews in German with better than a
 3-star rating. Note that while there is a single rating for the entire document,
@@ -44,3 +47,4 @@ page.
 [1]: http://www.contrib.andrew.cmu.edu/~shadow/sql/sql1992.txt
 [2]: /docs/search-apis/sql/func-opr
 [3]: https://en.wikipedia.org/wiki/Unix_time
+[4]: https://docs.vectara.com/docs/admin-apis/create-corpus#filter-attribute

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -163,6 +163,7 @@ module.exports = {
                     'search-apis/sql/filter-overview',
                     'search-apis/sql/func-opr',
                     'search-apis/sql/data-types',
+                    'search-apis/sql/ootb-filters',
                   ],
               },
               'search-apis/batched-queries',

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -156,6 +156,7 @@ module.exports = {
                 ]
               },
               'search-apis/reranking',
+              'search-apis/lexical-matching',
               {
                   type: 'category',
                   label: 'Filter Expressions',


### PR DESCRIPTION
Updates a few things:
- Adds Boolean types, since they're now official
- Adds details on the OOTB metadata filters that you can apply
- Adds cross-referencing of the corpus creation page to the query documentation

Also added to this:
- Booleans
- Exact text matching
- Neural and exact text blending