### PR TITLE
Add document deletion examples

### DIFF
--- a/www/docusaurus.config.js
+++ b/www/docusaurus.config.js
@@ -93,6 +93,13 @@ const config = {
           "php/rest/indexDocument.php",
           "python/vectara-rest/rest_index_document.py",
 
+          // delete documents
+          "csharp/rest/RestDeleteDocument.cs",
+          "java/rest/src/main/java/com/vectara/examples/rest/RestDeleteDocument.java",
+          "nodejs/rest/delete_document.js",
+          "php/rest/deleteDocument.php",
+          "python/vectara-rest/rest_delete_document.py",
+
           // file upload
           "java/rest/src/main/java/com/vectara/examples/rest/RestUploadFile.java",
           "nodejs/rest/upload_file.js",

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -130,7 +130,24 @@ module.exports = {
                   },
                 ]
               },
-              'indexing-apis/deleting-documents',
+              {
+                type: 'category',
+                label: 'Document Deletion API',
+                items: [
+                  'indexing-apis/deleting-documents',
+                  {
+                    type: 'category',
+                    label: 'REST Examples',
+                    items: [
+                      'getting-started-samples/RestDeleteDocument.cs',
+                      'getting-started-samples/RestDeleteDocument.java',
+                      'getting-started-samples/delete_document.js',
+                      'getting-started-samples/deleteDocument.php',
+                      'getting-started-samples/rest_delete_document.py',
+                    ]
+                  },
+                ]
+              },
             ],
         },
         {


### PR DESCRIPTION
Pretty simple addition: pulls in the document deletion examples that are now authored in the getting-started repo