### PR TITLE
Fix the assertion that API keys can't be used for indexing

### DIFF
--- a/www/docs/create_api_keys.md
+++ b/www/docs/create_api_keys.md
@@ -22,7 +22,7 @@ your account with an API key.
 
 :::
 
-Indexing and administrative actions cannot be performed through these keys.
+Administrative actions cannot be performed through these keys.
 
 The remainder of this guide walks you through managing and using the API Keys.
 


### PR DESCRIPTION
As it says: we assert that API keys can't be used for indexing, but that's no longer true