### PR TITLE
Fix buggy redirect for file upload filetypes

### DIFF
--- a/www/static/_redirects
+++ b/www/static/_redirects
@@ -7,6 +7,7 @@
 /docs/indexing-apis/format-for-upload                         /docs/api-reference/indexing-apis/format-for-upload
 /docs/indexing-apis/file-upload                               /docs/api-reference/indexing-apis/file-upload/file-upload
 /docs/indexing-apis/file-upload-filetypes                     /docs/api-reference/indexing-apis/file-upload/file-upload-filetypes
+/docs/indexing-apis/format-for-upload                         /docs/api-reference/indexing-apis/file-upload/format-for-upload
 /docs/indexing-apis/indexing                                  /docs/api-reference/indexing-apis/indexing
 /docs/protobuf-definitions                                    /docs/api-reference/protobuf-definitions
 /docs/rest                                                    /docs/api-reference/rest

--- a/www/static/_redirects
+++ b/www/static/_redirects
@@ -6,7 +6,7 @@
 /docs/indexing-apis/deleting-documents                        /docs/api-reference/indexing-apis/deleting-documents
 /docs/indexing-apis/format-for-upload                         /docs/api-reference/indexing-apis/format-for-upload
 /docs/indexing-apis/file-upload                               /docs/api-reference/indexing-apis/file-upload/file-upload
-/docs/indexing-apis/file-upload-filetypes                     /docs/api-reference/indexing-apis/file-upload-filetypes
+/docs/indexing-apis/file-upload-filetypes                     /docs/api-reference/indexing-apis/file-upload/file-upload-filetypes
 /docs/indexing-apis/indexing                                  /docs/api-reference/indexing-apis/indexing
 /docs/protobuf-definitions                                    /docs/api-reference/protobuf-definitions
 /docs/rest                                                    /docs/api-reference/rest


### PR DESCRIPTION
Mistakenly made one redirect in the file upload filetypes miss the `file-upload` prefix.  This fixes that