### PR TITLE
Add API Quickstart topic

### DIFF
--- a/www/docs/api-jumpstart.md
+++ b/www/docs/api-jumpstart.md
@@ -244,8 +244,109 @@ curl -L -X POST 'https://api.vectara.io/v1/index' \
 
 
 
-## Index the corpus
+## Query a term and return a specific number of results
 
+In this example, you want to search for the term "technology," and then return 
+only the first 5 results. 
+
+### Example cURL command
+
+```json
+
+curl -X POST "https://api.vectara.io/v1/query" \
+     -H "x-api-key: 12345" \
+     -H "customer-id: 7890" \
+     -d '{
+         "corpusId": "2",
+         "query": "technology",
+         "numResults": 5,
+         "start": 0
+     }'
+
+
+
+```
+
+### Example response with 5 results
+
+```json
+
+{
+  "status": "OK",
+  "results": [
+    {
+      "text": "The future of technology is AI.",
+      "score": 0.98,
+      "documentIndex": 1
+    },
+    {
+      "text": "Technology is evolving rapidly.",
+      "score": 0.95,
+      "documentIndex": 2
+    },
+    {
+      "text": "Blockchain technology is revolutionary.",
+      "score": 0.92,
+      "documentIndex": 3
+    },
+    {
+      "text": "Technology has its pros and cons.",
+      "score": 0.90,
+      "documentIndex": 4
+    },
+    {
+      "text": "The role of technology in modern society.",
+      "score": 0.88,
+      "documentIndex": 5
+    }
+  ]
+}
+
+```
+
+## Query with metadata filters
+
+In this example, you want to query _cloud computing_ with 10 results in 
+the _IT_ category.
+
+### Example cURL Command
+
+```json
+curl -X POST "https://api.vectara.io/v1/query" \
+     -H "x-api-key: 12345" \
+     -H "customer-id: 7890" \
+     -d '{
+         "corpusId": "2",
+         "query": "cloud computing",
+         "numResults": 10,
+         "metadataJson": {
+             "category": "IT"
+         }
+     }'
+
+
+### Example query response
+
+
+```json
+
+{
+  "status": "OK",
+  "results": [
+    {
+      "text": "Cloud computing is changing the IT landscape.",
+      "score": 0.99,
+      "documentIndex": 8
+    },
+    {
+      "text": "The benefits of cloud computing are numerous.",
+      "score": 0.96,
+      "documentIndex": 9
+    }
+  ]
+}
+
+```
 
 
 
@@ -253,8 +354,72 @@ curl -L -X POST 'https://api.vectara.io/v1/index' \
 1. 
 
 
-## Update data in a corpus
+## Create a new index and ingest a document
+
+In this example, you want to create a new index and ingest a new document in 
+this new index.
+
+1. Execute the following cURL command:
+
+   ```json
+   curl -X POST "https://api.vectara.io/v1/create-corpus" \
+     -H "x-api-key: 12345" \
+     -H "customer-id: 7890" \
+     -d '{
+         "name": "Tech Corpus"
+     }'
+
+   ```
+
+You get the following response:
+
+```json
+{
+  "status": "OK",
+  "corpusId": "3"
+}
+```
+
+2. Index a document into the new index with the following cURL command:
+
+   ```json
+   curl -X POST "https://api.vectara.io/v1/index" \
+     -H "x-api-key: 12345" \
+     -H "customer-id: 7890" \
+     -d '{
+         "corpusId": "3",
+         "documentId": "doc_1",
+         "text": "The future of technology is AI."
+     }'
+```
+   You get the following response:
+
+   ```json
+   {
+  "status": "OK"
+   }
+   ```
 
 
+## List all indices and delete a specific index
 
-1. 
+1. Execute the following curl command:
+
+   ```json
+   curl -X GET "https://api.vectara.io/v1/list-corpora" \
+     -H "x-api-key: 12345" \
+     -H "customer-id: 7890"
+```
+You get the following response:
+
+
+```json
+   {
+  "status": "OK",
+  "corpora": [
+    {"corpusId": "1", "name": "Default Corpus"},
+    {"corpusId": "2", "name": "My Corpus"},
+    {"corpusId": "3", "name": "Tech Corpus"}
+  ]
+}
+```

--- a/www/docs/api-jumpstart.md
+++ b/www/docs/api-jumpstart.md
@@ -1,0 +1,260 @@
+---
+id: api-jumpstart
+title: API Jumpstart
+sidebar_label: API Jumpstart
+---
+
+Let’s get you started with the Vectara API so that you can perform some 
+more advanced operations with your data. To use the API, you must have the 
+following information available:
+
+* Customer ID
+* Index ID
+* API Key
+
+:::note
+
+Some API functions require OAuth 2.0 through a client credentials grant. Learn 
+about how to create an application client and obtain a JWT Token.
+
+:::
+
+
+## Search for answers in the index
+
+Let’s continue using the Employee Handbook example from the 
+Now you want to ask another question, “How much PTO is offered to 
+employees each year?”
+
+You need to input the following information:
+
+* customer_id and customerId
+* API Key
+* corpus_id
+* query
+
+
+### Example curl command
+
+```json
+curl -L -X POST 'https://api.vectara.io/v1/query' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'customer-id: 123456789' \
+-H 'x-api-key: abc_12345defg67890hij09876' \
+--data-raw '{
+  "query": [
+    {
+      "query": "How much PTO is offered to employees each year?",
+      "start": 0,
+      "numResults": 10,
+      "contextConfig": {
+        "charsBefore": 30,
+        "charsAfter": 30,
+        "sentencesBefore": 3,
+        "sentencesAfter": 3,
+        "startTag": "<b>",
+        "endTag": "</b>"
+      },
+      "corpusKey": [
+        {
+          "customerId": 12345,
+          "corpusId": 1,
+          "semantics": "DEFAULT",
+          "dim": [
+            {
+              "name": "string",
+              "weight": 0
+            }
+          ],
+          "metadataFilter": "part.lang = '\''eng'\''",
+          "lexicalInterpolationConfig": {
+            "lambda": 0
+          }
+        }
+      ],
+      "rerankingConfig": {
+        "rerankerId": 272725717
+      },
+      "summary": [
+        {
+          "summarizerPromptName": "string",
+          "maxSummarizedResults": 0,
+          "responseLang": "string"
+        }
+      ]
+    }
+  ]
+}'
+```
+
+### Example JSON response
+
+Let’s take a closer look at the first response:
+
+```json
+{
+  "responseSet": [
+    {
+      "response": [
+        {
+          "text": "Employee Handbook PTO is 20 days a year for all new employees. <b>Employees earn more vacation days per year of service up to 5 extra days.</b> Example: Once you begin your 5th year, you now have 25 vacation days.",
+          "score": 4.30505,
+          "metadata": [
+            {
+              "name": "lang",
+              "value": "eng"
+            },
+            {
+              "name": "section",
+              "value": "1"
+            },
+            {
+              "name": "offset",
+              "value": "63"
+            },
+            {
+              "name": "len",
+              "value": "73"
+            }
+          ],
+          "documentIndex": 0,
+          "corpusKey": {
+            "customerId": 0,
+            "corpusId": 6,
+            "semantics": "DEFAULT",
+            "dim": [],
+            "metadataFilter": "",
+            "lexicalInterpolationConfig": null
+          },
+          "resultOffset": 66,
+          "resultLength": 73
+        },
+	  // More results....
+```
+
+The API provides the following response:
+
+"Employee Handbook PTO is 20 days a year for all new employees. <b>Employees 
+earn more vacation days per year of service up to 5 extra days.</b> 
+Example: Once you begin your 5th year, you now have 25 vacation days."
+
+
+## Upload a file to the index
+
+Since you already created an index, you can upload a new file with 
+a simple POST request.
+
+You need to input the following information:
+
+* customer_id
+* API Key
+* corpus_id
+* File name
+* Path to file
+
+In this example, you have a local rtf file that you want to upload to corpus 1.
+
+### Example curl command
+
+
+```json
+curl -L -X POST 'https://api.vectara.io/v1/upload?c=123456789&o=1&d=true' \
+-H 'Content-Type: multipart/form-data' \
+-H 'Accept: application/json' \
+-H 'x-api-key: zwt_asdfasdfasdfasdfasdfasdfasdfasdf' \
+-F 'file=@"//Users/username/Documents/tmp/doc.rtf"'
+```
+
+
+
+### Example JSON response
+
+The file uploads successfully and you get the following response:
+
+
+```json
+{"response":{
+  "status": {
+  },
+  "quotaConsumed": {
+    "numChars": "60",
+    "numMetadataChars": "148"
+  }
+},"document":{
+  "documentId": "doc.rtf",
+  "metadataJson": "{\"X-TIKA:Parsed-By\":\"org.apache.tika.parser.microsoft.rtf.RTFParser\",\"Content-Type\":\"application/rtf\"}",
+  "section": [{
+    "id": 1,
+    "text": "Simple test doc\n\nLorem ipsum \nLorem ipsum \nLorem ipsum \n "
+  }]
+}} 
+```
+
+## Index the document
+
+After you upload a document, you index the data to become searchable. Indexing 
+provides faster search results and also use fewer resources. An index is like 
+a snapshot of your data.
+
+In this example, you send a POST request to the /index endpoint along 
+with appropriate parameters:
+
+
+```json
+curl -L -X POST 'https://api.vectara.io/v1/index' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'customer-id: 12345' \
+-H 'x-api-key: asdfasdf' \
+--data-raw '{
+  "customerId": "12345",
+  "corpusId": 1,
+  "document": {
+    "documentId": "doc.rtf",
+    "title": "Sample test doc",
+    "description": "This doc is a sample",
+    "metadataJson": "{}",
+    "customDims": [
+      {
+        "name": "string",
+        "value": 0
+      }
+    ],
+    "section": [
+      {
+        "id": 0,
+        "title": "Section Title",
+        "text": "Text in this section",
+        "metadataJson": "string",
+        "customDims": [
+          {
+            "name": "string",
+            "value": 0
+          }
+        ],
+        "section": [
+          null
+        ]
+      }
+    ]
+  }
+}'
+```
+
+
+
+## Index the corpus
+
+
+
+
+
+1. 
+
+
+## Update data in a corpus
+
+
+
+1. 

--- a/www/docs/api-jumpstart.md
+++ b/www/docs/api-jumpstart.md
@@ -527,9 +527,7 @@ You get the following response:
      }
    ```
 
-3. Execute the curl command from Step 1 again:
-
-  You get the following response:
+3. Execute the curl command from Step 1 again. You get the following response: 
 
    ```js
    {

--- a/www/docs/api-jumpstart.md
+++ b/www/docs/api-jumpstart.md
@@ -4,37 +4,29 @@ title: API Jumpstart
 sidebar_label: API Jumpstart
 ---
 
-Let’s get you started with the Vectara API so that you can perform some 
-more advanced operations with your data. To use the API, you must have the 
-following information available:
+Let’s get you started with the <Config v="names.product"/> API so that you can perform some 
+more advanced operations with your data. To issue the types of API calls in these 
+examples, you must have the following information available:
 
 * Customer ID
 * Index ID
 * API Key
 
-:::note
+## Search for answers in an index
 
-Some API functions require OAuth 2.0 through a client credentials grant. Learn 
-about how to create an application client and obtain a JWT Token.
-
-:::
-
-
-## Search for answers in the index
-
-Let’s continue using the Employee Handbook example from the 
-Now you want to ask another question, “How much PTO is offered to 
-employees each year?”
+In this example, you already uploaded data from an Employee Handbook. Now you  
+want to issue an API call to ask, _“How much PTO is offered to 
+employees each year?”_
 
 You need to input the following information:
 
-* customer_id and customerId
-* API Key
-* corpus_id
-* query
+* `customer_id` and `customerId`
+* `x-api-key`
+* `corpus_id`
+* `query`
 
 
-### Example curl command
+### Example cURL command
 
 ```json
 curl -L -X POST 'https://api.vectara.io/v1/query' \
@@ -98,7 +90,10 @@ Let’s take a closer look at the first response:
     {
       "response": [
         {
-          "text": "Employee Handbook PTO is 20 days a year for all new employees. <b>Employees earn more vacation days per year of service up to 5 extra days.</b> Example: Once you begin your 5th year, you now have 25 vacation days.",
+          "text": "Employee Handbook PTO is 20 days a year for all new employees. 
+          <b>Employees earn more vacation days per year of service up to 5 extra 
+          days.</b> Example: Once you begin your 5th year, you now have 25 
+          vacation days.",
           "score": 4.30505,
           "metadata": [
             {
@@ -133,27 +128,29 @@ Let’s take a closer look at the first response:
 	  // More results....
 ```
 
-The API provides the following response:
+The example API call provides the following response:
 
-"Employee Handbook PTO is 20 days a year for all new employees. <b>Employees 
+_"Employee Handbook PTO is 20 days a year for all new employees. <b>Employees 
 earn more vacation days per year of service up to 5 extra days.</b> 
-Example: Once you begin your 5th year, you now have 25 vacation days."
+Example: Once you begin your 5th year, you now have 25 vacation days."_
 
+Let's take a look at some other API calls that you can make.
 
 ## Upload a file to the index
 
-Since you already created an index, you can upload a new file with 
+If you want to add a file to an existing index, you can upload a new file with 
 a simple POST request.
 
 You need to input the following information:
 
-* customer_id
-* API Key
-* corpus_id
-* File name
-* Path to file
+* `customer_id`
+* `x-api-key`
+* `corpus_id`
+* File name 
+* Path to the file
 
-In this example, you have a local rtf file that you want to upload to corpus 1.
+In this example, you have a local `.rtf` file that you want to upload to 
+index 1, which is `corpus_id` = 1.
 
 ### Example curl command
 
@@ -165,8 +162,6 @@ curl -L -X POST 'https://api.vectara.io/v1/upload?c=123456789&o=1&d=true' \
 -H 'x-api-key: zwt_asdfasdfasdfasdfasdfasdfasdfasdf' \
 -F 'file=@"//Users/username/Documents/tmp/doc.rtf"'
 ```
-
-
 
 ### Example JSON response
 
@@ -181,24 +176,26 @@ The file uploads successfully and you get the following response:
     "numChars": "60",
     "numMetadataChars": "148"
   }
-},"document":{
+  },"document":{
   "documentId": "doc.rtf",
   "metadataJson": "{\"X-TIKA:Parsed-By\":\"org.apache.tika.parser.microsoft.rtf.RTFParser\",\"Content-Type\":\"application/rtf\"}",
   "section": [{
     "id": 1,
     "text": "Simple test doc\n\nLorem ipsum \nLorem ipsum \nLorem ipsum \n "
-  }]
-}} 
+   }]
+  }} 
 ```
 
-## Index the document
+## Update and reindex the document
 
-After you upload a document, you index the data to become searchable. Indexing 
-provides faster search results and also use fewer resources. An index is like 
-a snapshot of your data.
+After you update a document, you can reindex the data to become searchable 
+with the updated content. Indexing provides faster search results and it also 
+use fewer resources. An index is like a snapshot of your data.
 
 In this example, you send a POST request to the /index endpoint along 
 with appropriate parameters:
+
+### Example cURL command
 
 
 ```json
@@ -242,17 +239,79 @@ curl -L -X POST 'https://api.vectara.io/v1/index' \
 }'
 ```
 
+### Example JSON Response
+
+```json
+{
+  "status": {
+    "code": "OK"
+  },
+  "quotaConsumed": {
+    "numChars": "250",
+    "numMetadataChars": "15"
+  }
+}
+
+```
+
+## Update the metadata of the uploaded file
+
+In this example, you want to add the following metadata to the `.rtf` file:
+
+* "Document-Version": "2.0" - Indicates that this is the second version of the document.
+* "Last-Modified-By": "JohnDoe" - Specifies the last person who modified the document.
+* "Security-Level": "High" - Indicates the security level of the updated document.
+* "Keywords": ["Quantum", "Physics", "Research"] - An array of keywords relevant to the document.
+
+Execute the following cURL command to update the document:
+
+  ```json
+  curl -L -X POST 'https://api.vectara.io/v1/index' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'customer-id: 12345' \
+-H 'x-api-key: asdfasdf' \
+--data-raw '{
+  "customerId": "12345",
+  "corpusId": 1,
+  "document": {
+    "documentId": "doc.rtf",
+    "metadataJson": "{\"X-TIKA:Parsed-By\":\"org.apache.tika.parser.microsoft.rtf.RTFParser\",\"Content-Type\":\"application/rtf\", \"Document-Version\":\"2.0\", \"Last-Modified-By\":\"JohnDoe\", \"Security-Level\":\"High\", \"Keywords\":[\"Quantum\", \"Physics\", \"Research\"]}"
+  }
+}'
+```
+You get the following JSON response:
+
+```json
+{
+  "response": {
+    "status": {
+      "code": "OK"
+    },
+    "quotaConsumed": {
+      "numChars": "60",
+      "numMetadataChars": "250"
+    }
+  },
+  "document": {
+    "documentId": "doc.rtf",
+    "metadataJson": "{\"X-TIKA:Parsed-By\":\"org.apache.tika.parser.microsoft.rtf.RTFParser\",\"Content-Type\":\"application/rtf\", \"Document-Version\":\"2.0\", \"Last-Modified-By\":\"JohnDoe\", \"Security-Level\":\"High\", \"Keywords\":[\"Quantum\", \"Physics\", \"Research\"]}"
+  }
+}
+```
+The metadataJson field now includes additional metadata that can help with 
+version tracking, identifying the last person who modified the document, 
+setting security levels, and categorizing the document based on keywords.
 
 
-## Query a term and return a specific number of results
+## Issue a query and return a specific number of results
 
-In this example, you want to search for the term "technology," and then return 
+In this query, you want to search for the term "technology" and then return 
 only the first 5 results. 
 
 ### Example cURL command
 
 ```json
-
 curl -X POST "https://api.vectara.io/v1/query" \
      -H "x-api-key: 12345" \
      -H "customer-id: 7890" \
@@ -262,15 +321,11 @@ curl -X POST "https://api.vectara.io/v1/query" \
          "numResults": 5,
          "start": 0
      }'
-
-
-
 ```
 
-### Example response with 5 results
+### Example JSON response with 5 results
 
 ```json
-
 {
   "status": "OK",
   "results": [
@@ -301,13 +356,12 @@ curl -X POST "https://api.vectara.io/v1/query" \
     }
   ]
 }
-
 ```
 
-## Query with metadata filters
+## Issue a query with metadata filters
 
-In this example, you want to query _cloud computing_ with 10 results in 
-the _IT_ category.
+In this example, you want to query the phrase _cloud computing_ with 2 
+results in the _IT_ category.
 
 ### Example cURL Command
 
@@ -318,18 +372,17 @@ curl -X POST "https://api.vectara.io/v1/query" \
      -d '{
          "corpusId": "2",
          "query": "cloud computing",
-         "numResults": 10,
+         "numResults": 2,
          "metadataJson": {
              "category": "IT"
          }
      }'
-
+```
 
 ### Example query response
 
 
 ```json
-
 {
   "status": "OK",
   "results": [
@@ -345,18 +398,10 @@ curl -X POST "https://api.vectara.io/v1/query" \
     }
   ]
 }
-
 ```
-
-
-
-
-1. 
-
-
 ## Create a new index and ingest a document
 
-In this example, you want to create a new index and ingest a new document in 
+In this example, you want to create a new index and also ingest a document in 
 this new index.
 
 1. Execute the following cURL command:
@@ -368,17 +413,16 @@ this new index.
      -d '{
          "name": "Tech Corpus"
      }'
-
    ```
 
-You get the following response:
+ You get the following response:
 
-```json
+ ```json
 {
   "status": "OK",
   "corpusId": "3"
 }
-```
+ ```
 
 2. Index a document into the new index with the following cURL command:
 
@@ -391,8 +435,9 @@ You get the following response:
          "documentId": "doc_1",
          "text": "The future of technology is AI."
      }'
-```
-   You get the following response:
+   ```
+
+ You get the following response:
 
    ```json
    {
@@ -403,23 +448,211 @@ You get the following response:
 
 ## List all indices and delete a specific index
 
-1. Execute the following curl command:
+1. Execute the following curl command to list the indices:
 
    ```json
    curl -X GET "https://api.vectara.io/v1/list-corpora" \
      -H "x-api-key: 12345" \
      -H "customer-id: 7890"
-```
+   ```
 You get the following response:
 
-
-```json
+   ```json
    {
   "status": "OK",
   "corpora": [
     {"corpusId": "1", "name": "Default Corpus"},
     {"corpusId": "2", "name": "My Corpus"},
     {"corpusId": "3", "name": "Tech Corpus"}
+    ]
+   }
+   ```
+
+2. Execute the following curl command to delete a specific index with `corpus_id` = 3.
+
+  ```json
+  curl -X DELETE "https://api.vectara.io/v1/delete-corpus" \
+     -H "x-api-key: 12345" \
+     -H "customer-id: 7890" \
+     -d '{
+         "corpusId": "3"
+     }'
+    ```
+
+     You get the following response:
+
+     ```json
+     {
+  "status": "OK"
+     }
+   ```
+
+
+3. Execute the curl command from Step 1 again:
+
+  You get the following response:
+
+   ```json
+   {
+  "status": "OK",
+  "corpora": [
+    {"corpusId": "1", "name": "Default Corpus"},
+    {"corpusId": "2", "name": "My Corpus"},
+    ]
+   }
+   ```
+  Notice that you only have 2 indices now.
+
+## Update a document, reindex the document, and query the index
+
+In this example, you want to update a documet with new information. Reindexing 
+the document improves data retrieval time when you ask a query. After the 
+reindex, you want to query the index and get a result from the updated information.
+
+1. Execute the following curl command to update an existing document in your 
+   index:
+
+   ```json
+   curl -X POST "https://api.vectara.io/v1/index" \
+  -H "x-api-key: 12345" \
+  -H "customer-id: 7890" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "corpusId": "2",
+    "document": {
+      "documentId": "quantum_doc_001",
+      "title": "Quantum Entanglement and Spacetime: An Updated Perspective",
+      "description": "An updated analysis on quantum entanglement and its implications on spacetime.",
+      "metadataJson": "{\"author\": \"Dr. Quantum\", \"field\": \"Quantum Physics\", \"version\": \"2.1\"}",
+      "parts": [
+        {
+          "text": "Quantum entanglement is a phenomenon where the states of two particles are correlated.",
+          "context": "Introduction"
+        },
+        {
+          "text": "Einstein's 'spooky action at a distance' has been experimentally verified.",
+          "context": "Historical Context"
+        },
+        {
+          "text": "Entanglement could be the key to a Theory of Everything.",
+          "context": "Recent Research"
+        }
+      ]
+    }
+  }'
+   ```
+   You get the following response:
+   
+   ```json
+   curl -X POST "https://api.vectara.io/v1/index" \
+  -H "x-api-key: 12345" \
+  -H "customer-id: 7890" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "corpusId": "2",
+    "document": {
+      "documentId": "quantum_doc_001",
+      "title": "Quantum Entanglement and Spacetime: An Updated Perspective",
+      "description": "An updated analysis on quantum entanglement and its implications on spacetime.",
+      "metadataJson": "{\"author\": \"Dr. Quantum\", \"field\": \"Quantum Physics\", \"version\": \"2.1\"}",
+      "parts": [
+        {
+          "text": "Quantum entanglement is a phenomenon where the states of two particles are correlated.",
+          "context": "Introduction"
+        },
+        {
+          "text": "Einstein's 'spooky action at a distance' has been experimentally verified.",
+          "context": "Historical Context"
+        },
+        {
+          "text": "Entanglement could be the key to a Theory of Everything.",
+          "context": "Recent Research"
+        }
+      ]
+    }
+  }'
+   ```
+
+2. Reindex the updated document:
+
+  ```json
+  curl -X POST "https://api.vectara.io/v1/core/index" \
+  -H "x-api-key: 12345" \
+  -H "customer-id: 7890" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "customerId": "7890",
+    "corpusId": "2",
+    "document": {
+      "documentId": "quantum_doc_001",
+      "metadataJson": "{\"author\": \"Dr. Quantum\", \"field\": \"Quantum Physics\", \"version\": \"2.1\"}",
+      "parts": [
+        {
+          "text": "Entanglement could be the key to a Theory of Everything.",
+          "context": "Recent Research"
+        }
+      ]
+    }
+  }'
+  ```
+  You get the following response:
+
+  ```json
+  {
+  "status": {
+    "code": "OK"
+    },
+  "quotaConsumed": {
+    "numChars": "100",
+    "numMetadataChars": "20"
+    }
+  }
+  ```
+
+3. Query the updated index:
+   
+   ```json
+   curl -X POST "https://api.vectara.io/v1/query" \
+  -H "x-api-key: 12345" \
+  -H "customer-id: 7890" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "corpusId": "2",
+    "query": "Is entanglement the key to a Theory of Everything?"
+  }'
+   ```
+   You get the following response:
+
+   ```json
+   {
+  "status": {
+    "code": "OK"
+  },
+  "results": [
+    {
+      "text": "Entanglement could be the key to a Theory of Everything.",
+      "score": 0.99,
+      "metadata": [
+        {
+          "key": "author",
+          "value": "Dr. Quantum"
+        },
+        {
+          "key": "field",
+          "value": "Quantum Physics"
+        },
+        {
+          "key": "version",
+          "value": "2.1"
+        }
+      ],
+      "documentIndex": 1,
+      "corpusKey": "quantum_doc_001"
+    }
   ]
 }
-```
+   ```
+In this final example, you updated an existing document to include new 
+information from the latest version of a document. You wanted to reindex 
+this updated document to ensure that the latest content is earchable. Finally, 
+you issued a query that asked a question about the new content.

--- a/www/docs/api-jumpstart.md
+++ b/www/docs/api-jumpstart.md
@@ -1,41 +1,48 @@
 ---
-id: api-jumpstart
-title: API Jumpstart
-sidebar_label: API Jumpstart
+id: api-recipes
+title: API Recipes
+sidebar_label: API Recipes
 ---
 import {Config} from '@site/docs/definitions.md';
 
-Using the API enables you to integrate the <Config v="names.product"/> search capabilities into your 
-applications. While the console UI offers a user-friendly interface for initial 
-testing and manual operations, the <Config v="names.product"/> API is where the 
-magic happens.
+Using our APIs enable application developers and data engineers to seamlessly 
+integrate the <Config v="names.product"/> semantic search capabilities into your applications. 
 
-As an application developer or data engineer, the API enables you to seamlessly 
-integrate semantic search into your applications. Let’s get you started with 
-the <Config v="names.product"/> API so that you can perform queries on 
-some data. 
+The Console UI and our APIs work hand-in-hand as part of the app development 
+process. For example, a builder uses this following workflow: 
+
+* Fine-tune a query's lambda and filters until the answer quality is just 
+  right.
+* Copy the request directly from the console and paste it into your IDE.
+* Copy the customer ID and API key from Console to further configure 
+  the request.
+* Test out the software and then verify that requests are hitting your 
+  index by checking the querying graph on the Overview tab.
+
+Let’s get you started with using the <Config v="names.product"/> APIs so that 
+you can perform queries on some data. 
 
 ## What you will learn
 
-We'll show you several example queries with some values in the parameters, and 
-then display example responses:
-* Search for answers in an index
-* Upload a file to the index
-* Update the metadata of an uploaded file
-* Issue a query and return a specific number of results
-* Issue a query with metadata filters
-* Create a new index and ingest a document
-* List all indices and delete a specific index
-* Update a document, reindex the document, and query the index 
+We'll show you several example API recipes that include queries with some 
+values in the parameters, and then display example responses:
+* [Search for answers in an index](/docs/api-recipes#search-for-answers-in-an-index)
+* [Upload a file to the index](/docs/api-recipes#upload-a-file-to-the-index)
+* [Update the metadata of an uploaded file](/docs/api-recipes#update-the-metadata-of-the-uploaded-file)
+* [Issue a query and return a specific number of results](/docs/api-recipes#issue-a-query-and-return-a-specific-number-of-results)
+* [Issue a query with metadata filters](/docs/api-recipes#issue-a-query-with-metadata-filters)
+* [Create a new index and ingest a document](/docs/api-recipes#create-a-new-index-and-ingest-a-document)
+* [List all indices and delete a specific index](/docs/api-recipes#list-all-indices-and-delete-a-specific-index)
+* [Update a document, reindex the document, and query the index](/docs/api-recipes#update-a-document-reindex-the-document-and-query-the-index)
 
-To issue the types of API calls in these examples, you typically need the 
+To issue the types of API calls in these recipes, you typically need the 
 following information that you can get from the console UI:
 
 * Customer ID
 * Index ID
 * API Key
 
-## Search for answers in an index
+### Search for answers in an index
 
 In this example, you have an index with uploaded data from an Employee 
 Handbook. Now you want to ask, _“How much PTO is offered to employees each 
@@ -50,11 +57,11 @@ field values:
 * `query` = How much PTO is offered to employees each year?
 
 
-### Example cURL command
+#### Example cURL command
 
 This example queries the index with the question about annual PTO.
 
-```json
+```js
 curl -L -X POST 'https://api.vectara.io/v1/query' \
 -H 'Content-Type: application/json' \
 -H 'Accept: application/json' \
@@ -106,11 +113,11 @@ curl -L -X POST 'https://api.vectara.io/v1/query' \
 }'
 ```
 
-### Example JSON response
+#### Example JSON response
 
 Let’s take a closer look at the first response:
 
-```json
+```js
 {
   "responseSet": [
     {
@@ -165,7 +172,7 @@ query, such as the language, section, and offset.
 
 Let's take a look at some other API calls that you can make.
 
-## Upload a file to the index
+### Upload a file to the index
 
 If you want to add a file to an existing index, you can upload a new file with 
 a simple command.
@@ -178,12 +185,12 @@ You need to input the following information:
 * File name 
 * Path to the file
 
-### Example cURL command
+#### Example cURL command
 
 In this example command, you have a local `doc.rtf` file that you want to upload to 
 index 1, which is `corpus_id` = 1.
 
-```json
+```js
 curl -L -X POST 'https://api.vectara.io/v1/upload?c=123456789&o=1&d=true' \
 -H 'Content-Type: multipart/form-data' \
 -H 'Accept: application/json' \
@@ -191,11 +198,11 @@ curl -L -X POST 'https://api.vectara.io/v1/upload?c=123456789&o=1&d=true' \
 -F 'file=@"//Users/username/Documents/tmp/doc.rtf"'
 ```
 
-### Example JSON response
+#### Example JSON response
 
 The file uploads successfully and you get the following response:
 
-```json
+```js
 {"response":{
   "status": {
   },
@@ -213,18 +220,18 @@ The file uploads successfully and you get the following response:
   }} 
 ```
 
-## Update and reindex the document
+### Update and reindex the document
 
 After you update a document, you can reindex the data to become searchable 
 with the updated content. Indexing provides faster search results and it also 
 use fewer resources. An index is like a snapshot of your data.
 
-### Example cURL command
+#### Example cURL command
 
 In this example, you send a POST request to the index endpoint along 
 with appropriate parameters:
 
-```json
+```js
 curl -L -X POST 'https://api.vectara.io/v1/index' \
 -H 'Content-Type: application/json' \
 -H 'Accept: application/json' \
@@ -265,9 +272,9 @@ curl -L -X POST 'https://api.vectara.io/v1/index' \
 }'
 ```
 
-### Example JSON Response
+#### Example JSON Response
 
-```json
+```js
 {
   "status": {
     "code": "OK"
@@ -280,7 +287,7 @@ curl -L -X POST 'https://api.vectara.io/v1/index' \
 
 ```
 
-## Update the metadata of the uploaded file
+### Update the metadata of the uploaded file
 
 Metadata serves as a critical component of improving search results because it 
 more precise filtering and adds important context. If you have really good 
@@ -292,9 +299,11 @@ this example, you want to add the following metadata to the `.rtf` file:
 * "Security-Level": "High" - Indicates the security level of the updated document.
 * "Keywords": ["Quantum", "Physics", "Research"] - An array of keywords relevant to the document.
 
+#### Example cURL Command
+
 Execute the following cURL command to update the document:
 
-  ```json
+  ```js
   curl -L -X POST 'https://api.vectara.io/v1/index' \
 -H 'Content-Type: application/json' \
 -H 'Accept: application/json' \
@@ -309,9 +318,11 @@ Execute the following cURL command to update the document:
   }
 }'
 ```
+#### Example JSON Response
+
 You get the following JSON response:
 
-```json
+```js
 {
   "response": {
     "status": {
@@ -333,14 +344,14 @@ version tracking, identifying the last person who modified the document,
 setting security levels, and categorizing the document based on keywords.
 
 
-## Issue a query and return a specific number of results
+### Issue a query and return a specific number of results
 
 In this query, you want to search for the term "technology" and then return 
 only the first 5 results. 
 
-### Example cURL command
+#### Example cURL command
 
-```json
+```js
 curl -X POST "https://api.vectara.io/v1/query" \
      -H "x-api-key: abc_12345defg67890hij09876" \
      -H "customer-id: 123456789" \
@@ -352,9 +363,9 @@ curl -X POST "https://api.vectara.io/v1/query" \
      }'
 ```
 
-### Example JSON response with 5 results
+#### Example JSON response with 5 results
 
-```json
+```js
 {
   "status": "OK",
   "results": [
@@ -387,14 +398,14 @@ curl -X POST "https://api.vectara.io/v1/query" \
 }
 ```
 
-## Issue a query with metadata filters
+### Issue a query with metadata filters
 
 In this example, you want to query the phrase _cloud computing_ with 2 
 results in the _IT_ category.
 
-### Example cURL Command
+#### Example cURL command
 
-```json
+```js
 curl -X POST "https://api.vectara.io/v1/query" \
      -H "x-api-key: abc_12345defg67890hij09876" \
      -H "customer-id: 123456789" \
@@ -408,10 +419,10 @@ curl -X POST "https://api.vectara.io/v1/query" \
      }'
 ```
 
-### Example JSON response
+#### Example JSON response
 
 
-```json
+```js
 {
   "status": "OK",
   "results": [
@@ -428,14 +439,14 @@ curl -X POST "https://api.vectara.io/v1/query" \
   ]
 }
 ```
-## Create a new index and ingest a document
+### Create a new index and ingest a document
 
 In this example, you want to create a new index and also ingest a document in 
 this new index.
 
 1. Execute the following cURL command:
 
-   ```json
+   ```js
    curl -X POST "https://api.vectara.io/v1/create-corpus" \
      -H "x-api-key: abc_12345defg67890hij09876" \
      -H "customer-id: 123456789" \
@@ -446,7 +457,7 @@ this new index.
 
  You get the following response:
 
- ```json
+ ```js
 {
   "status": "OK",
   "corpusId": "3"
@@ -455,7 +466,7 @@ this new index.
 
 2. Index a document into the new index with the following cURL command:
 
-   ```json
+   ```js
    curl -X POST "https://api.vectara.io/v1/index" \
      -H "x-api-key: abc_12345defg67890hij09876" \
      -H "customer-id: 123456789" \
@@ -468,25 +479,25 @@ this new index.
 
  You get the following response:
 
-   ```json
+   ```js
    {
   "status": "OK"
    }
    ```
 
 
-## List all indices and delete a specific index
+### List all indices and delete a specific index
 
 1. Execute the following curl command to list the indices:
 
-   ```json
+   ```js
    curl -X GET "https://api.vectara.io/v1/list-corpora" \
      -H "x-api-key: abc_12345defg67890hij09876" \
      -H "customer-id: 123456789"
    ```
 You get the following response:
 
-   ```json
+   ```js
    {
   "status": "OK",
   "corpora": [
@@ -499,7 +510,7 @@ You get the following response:
 
 2. Execute the following curl command to delete a specific index with `corpus_id` = 3.
 
-  ```json
+  ```js
   curl -X DELETE "https://api.vectara.io/v1/delete-corpus" \
      -H "x-api-key: abc_12345defg67890hij09876" \
      -H "customer-id: 123456789" \
@@ -510,7 +521,7 @@ You get the following response:
 
      You get the following response:
 
-     ```json
+     ```js
      {
   "status": "OK"
      }
@@ -520,7 +531,7 @@ You get the following response:
 
   You get the following response:
 
-   ```json
+   ```js
    {
   "status": "OK",
   "corpora": [
@@ -531,7 +542,7 @@ You get the following response:
    ```
   Notice that you only have 2 indices now.
 
-## Update a document, reindex the document, and query the index
+### Update a document, reindex the document, and query the index
 
 In this example, you want to update a document with new information. Reindexing 
 the document improves data retrieval time when you ask a query. After the 
@@ -540,7 +551,7 @@ reindex, you want to query the index and get a result from the updated informati
 1. Execute the following curl command to update an existing document in your 
    index:
 
-   ```json
+   ```js
    curl -X POST "https://api.vectara.io/v1/index" \
   -H "x-api-key: abc_12345defg67890hij09876" \
   -H "customer-id: 123456789" \
@@ -571,7 +582,7 @@ reindex, you want to query the index and get a result from the updated informati
    ```
    You get the following response:
    
-   ```json
+   ```js
    {
   "status": {
     "code": "OK"
@@ -585,7 +596,7 @@ reindex, you want to query the index and get a result from the updated informati
 
 2. Reindex the updated document:
 
-  ```json
+  ```js
   curl -X POST "https://api.vectara.io/v1/core/index" \
   -H "x-api-key: abc_12345defg67890hij09876" \
   -H "customer-id: 123456789" \
@@ -607,7 +618,7 @@ reindex, you want to query the index and get a result from the updated informati
   ```
   You get the following response:
 
-  ```json
+  ```js
   {
   "status": {
     "code": "OK"
@@ -621,7 +632,7 @@ reindex, you want to query the index and get a result from the updated informati
 
 3. Query the updated index:
    
-   ```json
+   ```js
    curl -X POST "https://api.vectara.io/v1/query" \
   -H "x-api-key: abc_12345defg67890hij09876" \
   -H "customer-id: 123456789" \
@@ -633,7 +644,7 @@ reindex, you want to query the index and get a result from the updated informati
    ```
    You get the following response:
 
-   ```json
+   ```js
    {
   "status": {
     "code": "OK"
@@ -668,5 +679,5 @@ information from the latest version of a document. You wanted to reindex
 this updated document to ensure that the latest content is searchable. 
 Finally, you issued a query that asked a question about the new content.
 
-Thie API jumpstart provided a variety of query examples that you can leverage 
+This API recipes section provided a variety of query examples that you can leverage 
 as you start building with <Config v="names.product"/>.

--- a/www/docs/api-jumpstart.md
+++ b/www/docs/api-jumpstart.md
@@ -408,7 +408,7 @@ curl -X POST "https://api.vectara.io/v1/query" \
      }'
 ```
 
-### Example query response
+### Example JSON response
 
 
 ```json

--- a/www/docs/api-jumpstart.md
+++ b/www/docs/api-jumpstart.md
@@ -3,10 +3,33 @@ id: api-jumpstart
 title: API Jumpstart
 sidebar_label: API Jumpstart
 ---
+import {Config} from '@site/docs/definitions.md';
 
-Let’s get you started with the <Config v="names.product"/> API so that you can perform some 
-more advanced operations with your data. To issue the types of API calls in these 
-examples, you must have the following information available:
+Using the API enables you to integrate the <Config v="names.product"/> search capabilities into your 
+applications. While the console UI offers a user-friendly interface for initial 
+testing and manual operations, the <Config v="names.product"/> API is where the 
+magic happens.
+
+As an application developer or data engineer, the API enables you to seamlessly 
+integrate semantic search into your applications. Let’s get you started with 
+the <Config v="names.product"/> API so that you can perform queries on 
+some data. 
+
+## What you will learn
+
+We'll show you several example queries with some values in the parameters, and 
+then display example responses:
+* Search for answers in an index
+* Upload a file to the index
+* Update the metadata of an uploaded file
+* Issue a query and return a specific number of results
+* Issue a query with metadata filters
+* Create a new index and ingest a document
+* List all indices and delete a specific index
+* Update a document, reindex the document, and query the index 
+
+To issue the types of API calls in these examples, you typically need the 
+following information that you can get from the console UI:
 
 * Customer ID
 * Index ID
@@ -14,19 +37,22 @@ examples, you must have the following information available:
 
 ## Search for answers in an index
 
-In this example, you already uploaded data from an Employee Handbook. Now you  
-want to issue an API call to ask, _“How much PTO is offered to 
-employees each year?”_
+In this example, you have an index with uploaded data from an Employee 
+Handbook. Now you want to ask, _“How much PTO is offered to employees each 
+year?”_
 
-You need to input the following information:
+To issue the cURL command in the example, you input the following 
+field values:
 
-* `customer_id` and `customerId`
-* `x-api-key`
-* `corpus_id`
-* `query`
+* `customer_id` and `customerId` = 123456789
+* `x-api-key` = abc_12345defg67890hij09876
+* `corpus_id` = 1
+* `query` = How much PTO is offered to employees each year?
 
 
 ### Example cURL command
+
+This example queries the index with the question about annual PTO.
 
 ```json
 curl -L -X POST 'https://api.vectara.io/v1/query' \
@@ -50,7 +76,7 @@ curl -L -X POST 'https://api.vectara.io/v1/query' \
       },
       "corpusKey": [
         {
-          "customerId": 12345,
+          "customerId": 123456789,
           "corpusId": 1,
           "semantics": "DEFAULT",
           "dim": [
@@ -115,8 +141,8 @@ Let’s take a closer look at the first response:
           ],
           "documentIndex": 0,
           "corpusKey": {
-            "customerId": 0,
-            "corpusId": 6,
+            "customerId": 1,
+            "corpusId": 123456789,
             "semantics": "DEFAULT",
             "dim": [],
             "metadataFilter": "",
@@ -128,18 +154,21 @@ Let’s take a closer look at the first response:
 	  // More results....
 ```
 
-The example API call provides the following response:
+The example API call provided the following response:
 
 _"Employee Handbook PTO is 20 days a year for all new employees. <b>Employees 
 earn more vacation days per year of service up to 5 extra days.</b> 
 Example: Once you begin your 5th year, you now have 25 vacation days."_
+
+The result answers the question and returns additional details about the 
+query, such as the language, section, and offset. 
 
 Let's take a look at some other API calls that you can make.
 
 ## Upload a file to the index
 
 If you want to add a file to an existing index, you can upload a new file with 
-a simple POST request.
+a simple command.
 
 You need to input the following information:
 
@@ -149,24 +178,22 @@ You need to input the following information:
 * File name 
 * Path to the file
 
-In this example, you have a local `.rtf` file that you want to upload to 
+### Example cURL command
+
+In this example command, you have a local `doc.rtf` file that you want to upload to 
 index 1, which is `corpus_id` = 1.
-
-### Example curl command
-
 
 ```json
 curl -L -X POST 'https://api.vectara.io/v1/upload?c=123456789&o=1&d=true' \
 -H 'Content-Type: multipart/form-data' \
 -H 'Accept: application/json' \
--H 'x-api-key: zwt_asdfasdfasdfasdfasdfasdfasdfasdf' \
+-H 'x-api-key: abc_12345defg67890hij09876' \
 -F 'file=@"//Users/username/Documents/tmp/doc.rtf"'
 ```
 
 ### Example JSON response
 
 The file uploads successfully and you get the following response:
-
 
 ```json
 {"response":{
@@ -192,20 +219,19 @@ After you update a document, you can reindex the data to become searchable
 with the updated content. Indexing provides faster search results and it also 
 use fewer resources. An index is like a snapshot of your data.
 
-In this example, you send a POST request to the /index endpoint along 
-with appropriate parameters:
-
 ### Example cURL command
 
+In this example, you send a POST request to the index endpoint along 
+with appropriate parameters:
 
 ```json
 curl -L -X POST 'https://api.vectara.io/v1/index' \
 -H 'Content-Type: application/json' \
 -H 'Accept: application/json' \
--H 'customer-id: 12345' \
--H 'x-api-key: asdfasdf' \
+-H 'customer-id: 123456789' \
+-H 'x-api-key: abc_12345defg67890hij09876' \
 --data-raw '{
-  "customerId": "12345",
+  "customerId": "123456789",
   "corpusId": 1,
   "document": {
     "documentId": "doc.rtf",
@@ -256,10 +282,13 @@ curl -L -X POST 'https://api.vectara.io/v1/index' \
 
 ## Update the metadata of the uploaded file
 
-In this example, you want to add the following metadata to the `.rtf` file:
+Metadata serves as a critical component of improving search results because it 
+more precise filtering and adds important context. If you have really good 
+metadata, it helps ensure that data retrieval completes more effectively. In 
+this example, you want to add the following metadata to the `.rtf` file:
 
 * "Document-Version": "2.0" - Indicates that this is the second version of the document.
-* "Last-Modified-By": "JohnDoe" - Specifies the last person who modified the document.
+* "Last-Modified-By": "DrQuantum" - Specifies the last person who modified the document.
 * "Security-Level": "High" - Indicates the security level of the updated document.
 * "Keywords": ["Quantum", "Physics", "Research"] - An array of keywords relevant to the document.
 
@@ -269,14 +298,14 @@ Execute the following cURL command to update the document:
   curl -L -X POST 'https://api.vectara.io/v1/index' \
 -H 'Content-Type: application/json' \
 -H 'Accept: application/json' \
--H 'customer-id: 12345' \
--H 'x-api-key: asdfasdf' \
+-H 'customer-id: 123456789' \
+-H 'x-api-key: abc_12345defg67890hij09876' \
 --data-raw '{
-  "customerId": "12345",
+  "customerId": "123456789",
   "corpusId": 1,
   "document": {
     "documentId": "doc.rtf",
-    "metadataJson": "{\"X-TIKA:Parsed-By\":\"org.apache.tika.parser.microsoft.rtf.RTFParser\",\"Content-Type\":\"application/rtf\", \"Document-Version\":\"2.0\", \"Last-Modified-By\":\"JohnDoe\", \"Security-Level\":\"High\", \"Keywords\":[\"Quantum\", \"Physics\", \"Research\"]}"
+    "metadataJson": "{\"X-TIKA:Parsed-By\":\"org.apache.tika.parser.microsoft.rtf.RTFParser\",\"Content-Type\":\"application/rtf\", \"Document-Version\":\"2.0\", \"Last-Modified-By\":\"DrQuantum\", \"Security-Level\":\"High\", \"Keywords\":[\"Quantum\", \"Physics\", \"Research\"]}"
   }
 }'
 ```
@@ -295,7 +324,7 @@ You get the following JSON response:
   },
   "document": {
     "documentId": "doc.rtf",
-    "metadataJson": "{\"X-TIKA:Parsed-By\":\"org.apache.tika.parser.microsoft.rtf.RTFParser\",\"Content-Type\":\"application/rtf\", \"Document-Version\":\"2.0\", \"Last-Modified-By\":\"JohnDoe\", \"Security-Level\":\"High\", \"Keywords\":[\"Quantum\", \"Physics\", \"Research\"]}"
+    "metadataJson": "{\"X-TIKA:Parsed-By\":\"org.apache.tika.parser.microsoft.rtf.RTFParser\",\"Content-Type\":\"application/rtf\", \"Document-Version\":\"2.0\", \"Last-Modified-By\":\"DrQuantum\", \"Security-Level\":\"High\", \"Keywords\":[\"Quantum\", \"Physics\", \"Research\"]}"
   }
 }
 ```
@@ -313,8 +342,8 @@ only the first 5 results.
 
 ```json
 curl -X POST "https://api.vectara.io/v1/query" \
-     -H "x-api-key: 12345" \
-     -H "customer-id: 7890" \
+     -H "x-api-key: abc_12345defg67890hij09876" \
+     -H "customer-id: 123456789" \
      -d '{
          "corpusId": "2",
          "query": "technology",
@@ -340,7 +369,7 @@ curl -X POST "https://api.vectara.io/v1/query" \
       "documentIndex": 2
     },
     {
-      "text": "Blockchain technology is revolutionary.",
+      "text": "Generative AI technology is revolutionary.",
       "score": 0.92,
       "documentIndex": 3
     },
@@ -367,11 +396,11 @@ results in the _IT_ category.
 
 ```json
 curl -X POST "https://api.vectara.io/v1/query" \
-     -H "x-api-key: 12345" \
-     -H "customer-id: 7890" \
+     -H "x-api-key: abc_12345defg67890hij09876" \
+     -H "customer-id: 123456789" \
      -d '{
          "corpusId": "2",
-         "query": "cloud computing",
+         "query": "IT,
          "numResults": 2,
          "metadataJson": {
              "category": "IT"
@@ -387,12 +416,12 @@ curl -X POST "https://api.vectara.io/v1/query" \
   "status": "OK",
   "results": [
     {
-      "text": "Cloud computing is changing the IT landscape.",
+      "text": "Generative AI is changing the IT landscape.",
       "score": 0.99,
       "documentIndex": 8
     },
     {
-      "text": "The benefits of cloud computing are numerous.",
+      "text": "The benefits of Generative AI are numerous.",
       "score": 0.96,
       "documentIndex": 9
     }
@@ -408,10 +437,10 @@ this new index.
 
    ```json
    curl -X POST "https://api.vectara.io/v1/create-corpus" \
-     -H "x-api-key: 12345" \
-     -H "customer-id: 7890" \
+     -H "x-api-key: abc_12345defg67890hij09876" \
+     -H "customer-id: 123456789" \
      -d '{
-         "name": "Tech Corpus"
+         "name": "AI Future"
      }'
    ```
 
@@ -428,8 +457,8 @@ this new index.
 
    ```json
    curl -X POST "https://api.vectara.io/v1/index" \
-     -H "x-api-key: 12345" \
-     -H "customer-id: 7890" \
+     -H "x-api-key: abc_12345defg67890hij09876" \
+     -H "customer-id: 123456789" \
      -d '{
          "corpusId": "3",
          "documentId": "doc_1",
@@ -452,8 +481,8 @@ this new index.
 
    ```json
    curl -X GET "https://api.vectara.io/v1/list-corpora" \
-     -H "x-api-key: 12345" \
-     -H "customer-id: 7890"
+     -H "x-api-key: abc_12345defg67890hij09876" \
+     -H "customer-id: 123456789"
    ```
 You get the following response:
 
@@ -461,9 +490,9 @@ You get the following response:
    {
   "status": "OK",
   "corpora": [
-    {"corpusId": "1", "name": "Default Corpus"},
-    {"corpusId": "2", "name": "My Corpus"},
-    {"corpusId": "3", "name": "Tech Corpus"}
+    {"corpusId": "1", "name": "Modern AI"},
+    {"corpusId": "2", "name": "AI Now"},
+    {"corpusId": "3", "name": "AI Future"}
     ]
    }
    ```
@@ -472,8 +501,8 @@ You get the following response:
 
   ```json
   curl -X DELETE "https://api.vectara.io/v1/delete-corpus" \
-     -H "x-api-key: 12345" \
-     -H "customer-id: 7890" \
+     -H "x-api-key: abc_12345defg67890hij09876" \
+     -H "customer-id: 123456789" \
      -d '{
          "corpusId": "3"
      }'
@@ -487,7 +516,6 @@ You get the following response:
      }
    ```
 
-
 3. Execute the curl command from Step 1 again:
 
   You get the following response:
@@ -496,8 +524,8 @@ You get the following response:
    {
   "status": "OK",
   "corpora": [
-    {"corpusId": "1", "name": "Default Corpus"},
-    {"corpusId": "2", "name": "My Corpus"},
+    {"corpusId": "1", "name": "Modern AI"},
+    {"corpusId": "2", "name": "AI Now"},
     ]
    }
    ```
@@ -505,7 +533,7 @@ You get the following response:
 
 ## Update a document, reindex the document, and query the index
 
-In this example, you want to update a documet with new information. Reindexing 
+In this example, you want to update a document with new information. Reindexing 
 the document improves data retrieval time when you ask a query. After the 
 reindex, you want to query the index and get a result from the updated information.
 
@@ -514,8 +542,8 @@ reindex, you want to query the index and get a result from the updated informati
 
    ```json
    curl -X POST "https://api.vectara.io/v1/index" \
-  -H "x-api-key: 12345" \
-  -H "customer-id: 7890" \
+  -H "x-api-key: abc_12345defg67890hij09876" \
+  -H "customer-id: 123456789" \
   -H "Content-Type: application/json" \
   -d '{
     "corpusId": "2",
@@ -544,44 +572,26 @@ reindex, you want to query the index and get a result from the updated informati
    You get the following response:
    
    ```json
-   curl -X POST "https://api.vectara.io/v1/index" \
-  -H "x-api-key: 12345" \
-  -H "customer-id: 7890" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "corpusId": "2",
-    "document": {
-      "documentId": "quantum_doc_001",
-      "title": "Quantum Entanglement and Spacetime: An Updated Perspective",
-      "description": "An updated analysis on quantum entanglement and its implications on spacetime.",
-      "metadataJson": "{\"author\": \"Dr. Quantum\", \"field\": \"Quantum Physics\", \"version\": \"2.1\"}",
-      "parts": [
-        {
-          "text": "Quantum entanglement is a phenomenon where the states of two particles are correlated.",
-          "context": "Introduction"
-        },
-        {
-          "text": "Einstein's 'spooky action at a distance' has been experimentally verified.",
-          "context": "Historical Context"
-        },
-        {
-          "text": "Entanglement could be the key to a Theory of Everything.",
-          "context": "Recent Research"
-        }
-      ]
+   {
+  "status": {
+    "code": "OK"
+    },
+  "quotaConsumed": {
+    "numChars": "330",
+    "numMetadataChars": "65"
     }
-  }'
+  }
    ```
 
 2. Reindex the updated document:
 
   ```json
   curl -X POST "https://api.vectara.io/v1/core/index" \
-  -H "x-api-key: 12345" \
-  -H "customer-id: 7890" \
+  -H "x-api-key: abc_12345defg67890hij09876" \
+  -H "customer-id: 123456789" \
   -H "Content-Type: application/json" \
   -d '{
-    "customerId": "7890",
+    "customerId": "123456789",
     "corpusId": "2",
     "document": {
       "documentId": "quantum_doc_001",
@@ -613,8 +623,8 @@ reindex, you want to query the index and get a result from the updated informati
    
    ```json
    curl -X POST "https://api.vectara.io/v1/query" \
-  -H "x-api-key: 12345" \
-  -H "customer-id: 7890" \
+  -H "x-api-key: abc_12345defg67890hij09876" \
+  -H "customer-id: 123456789" \
   -H "Content-Type: application/json" \
   -d '{
     "corpusId": "2",
@@ -652,7 +662,11 @@ reindex, you want to query the index and get a result from the updated informati
   ]
 }
    ```
+
 In this final example, you updated an existing document to include new 
 information from the latest version of a document. You wanted to reindex 
-this updated document to ensure that the latest content is earchable. Finally, 
-you issued a query that asked a question about the new content.
+this updated document to ensure that the latest content is searchable. 
+Finally, you issued a query that asked a question about the new content.
+
+Thie API jumpstart provided a variety of query examples that you can leverage 
+as you start building with <Config v="names.product"/>.

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -21,6 +21,11 @@ module.exports = {
           label: "Quick Start",
         },
         {
+          type: 'doc',
+          id: 'api-jumpstart',
+          label: "API Jumpstart",
+        },
+        {
           type: 'category',
           label: 'Common API Paradigms',
           items: [

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -22,8 +22,8 @@ module.exports = {
         },
         {
           type: 'doc',
-          id: 'api-jumpstart',
-          label: "API Jumpstart",
+          id: 'api-recipes',
+          label: "API Recipes",
         },
         {
           type: 'category',


### PR DESCRIPTION
Added a quick start topic for the API called API Jumpstart. The intent is to show a variety of basic queries around searching, uploading files, updating metadata, listing indices, etc. This topic does not include humorous examples like the console quickstart because I started this draft a while ago. I can make the content more engaging and entertaining if necessary.

My vision is to have additional examples throughout the documentation that are more advanced and showcase more real-world situations that explain what we're doing and why, e.g. more examples about metadata.