### PR TITLE
Update Code Samples with specific category for Query Operations

### DIFF
--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -101,13 +101,21 @@ module.exports = {
     {
       type: 'category',
       label: 'Code Samples',
+      collapsed: false,
       items: [
-        'getting-started-samples/RestApiKeyQueries.cs',
-        'getting-started-samples/RestApiKeyQueries.java',
-        'getting-started-samples/queryDataApiKey.php',
-        'getting-started-samples/rest_api_key_queries.py',
-        'getting-started-samples/app.js',
-      ]
+        {
+          type: 'category',
+          label: 'Query Operations Code Samples',
+          collapsed: false,
+          items: [
+            'getting-started-samples/RestApiKeyQueries.cs',
+            'getting-started-samples/RestApiKeyQueries.java',
+            'getting-started-samples/queryDataApiKey.php',
+            'getting-started-samples/rest_api_key_queries.py',
+            'getting-started-samples/app.js',
+          ]
+        }
+     ]
     },
     {
       type: 'category',


### PR DESCRIPTION
Move examples into new category since they specific to query operations. This will allow us to expand the code samples in the future, such as Indexing-specific examples