### PR TITLE
Add API Keys topics to API Reference

### DIFF
--- a/www/docs/api-reference/api-keys/create-api-key.md
+++ b/www/docs/api-reference/api-keys/create-api-key.md
@@ -4,20 +4,30 @@ title: Create API Key API Definition
 sidebar_label: Create API Key API Definition
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
 The Create API Key endpoint lets you create new API keys, which you can 
 bind to one or multiple corpora. You also decide whether to designate each key
-for specific access like only querying (read-only) or querying and indexing 
-(read-write).
+for specific access like only querying (read-only) or both querying and 
+indexing (read-write).
 
+This is useful in scenarios where you have applications that 
+require different levels of access to corpora data. For example, you might 
+create a read-only API key for an application that only nees to query data.
 
 ## Create API Key Endpoint Address
 
 <Config v="names.product"/> exposes a REST endpoint at the following URL
 to index content into a corpus:
 <code>https://<Config v="domains.rest.indexing"/>/v1/create-api-key</code>
+
+## Create an API Key from the API Playground
+
+Check out our [interactive API Playground](/docs/rest-api/create-api-key) that lets 
+you experiment with this REST endpoint to create API keys for your account.
 
 ### Request Headers
 
@@ -29,10 +39,11 @@ headers:
 
 ### Request Body
 
-The possible values for apiKeyType are API_KEY_TYPE__UNDEFINED (default), 
-API_KEY_TYPE__SERVING, and API_KEY_TYPE__SERVING_INDEXING.
-
-You also specify the corpus IDs of where you want to bind the API key.
+The Create API Key request body requires the following parameters:
+* `description` - Provides details about the API key
+* `apiKeyType` - Indicates the type of API key including `API_KEY_TYPE__UNDEFINED` 
+  (default), `API_KEY_TYPE__SERVING`, or `API_KEY_TYPE__SERVING_INDEXING`.
+* `corpusId` - Specifies the corpus IDs where you want to bind the API key.
 
 ```json
 {

--- a/www/docs/api-reference/api-keys/create-api-key.md
+++ b/www/docs/api-reference/api-keys/create-api-key.md
@@ -4,24 +4,46 @@ title: Create API Key API Definition
 sidebar_label: Create API Key API Definition
 ---
 
-The Create API keys endpoint lets users create new API keys, which you can 
-bind to one or multiple corpora and designate for specific access, including 
-quering, indexing, or both.
+import {Config} from '@site/docs/definitions.md';
+import {vars} from '@site/static/variables.json';
+
+The Create API Key endpoint lets you create new API keys, which you can 
+bind to one or multiple corpora. You also decide whether to designate each key
+for specific access like only querying (read-only) or querying and indexing 
+(read-write).
 
 
 ## Create API Key Endpoint Address
 
-https://api.vectara.io/v1/create-api-key
+<Config v="names.product"/> exposes a REST endpoint at the following URL
+to index content into a corpus:
+<code>https://<Config v="domains.rest.indexing"/>/v1/create-api-key</code>
 
 ### Request Headers
 
-abc
+To interact with the Index service via REST calls, you need the following 
+headers:
+
+* `customer_id` is the customer ID to use for the request.
+* An JWT token as your authentication method
 
 ### Request Body
 
+The possible values for apiKeyType are API_KEY_TYPE__UNDEFINED (default), 
+API_KEY_TYPE__SERVING, and API_KEY_TYPE__SERVING_INDEXING.
 
+You also specify the corpus IDs of where you want to bind the API key.
 
 ```json
-// code sample with fields explained if not obvious in previous paragraph
-
+{
+  "apiKeyData": [
+    {
+      "description": "Description of the ApiKey.",
+      "apiKeyType": "API_KEY_TYPE__UNDEFINED",
+      "corpusId": [
+        12
+      ]
+    }
+  ]
+}
 ```

--- a/www/docs/api-reference/api-keys/create-api-key.md
+++ b/www/docs/api-reference/api-keys/create-api-key.md
@@ -10,13 +10,13 @@ import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
 The Create API Key endpoint lets you create new API keys, which you can 
-bind to one or multiple corpora. You also decide whether to designate each key
-for specific access like only querying (read-only) or both querying and 
+bind to one or multiple corpora. You can also decide whether to designate each 
+key for specific access like only querying (read-only) or both querying and 
 indexing (read-write).
 
-This is useful in scenarios where you have applications that 
+This capability is useful in scenarios where you have applications that 
 require different levels of access to corpora data. For example, you might 
-create a read-only API key for an application that only nees to query data.
+create a read-only API key for an application that only needs to query data.
 
 ## Create API Key Endpoint Address
 

--- a/www/docs/api-reference/api-keys/create-api-key.md
+++ b/www/docs/api-reference/api-keys/create-api-key.md
@@ -1,0 +1,27 @@
+---
+id: create-api-key
+title: Create API Key API Definition
+sidebar_label: Create API Key API Definition
+---
+
+The Create API keys endpoint lets users create new API keys, which you can 
+bind to one or multiple corpora and designate for specific access, including 
+quering, indexing, or both.
+
+
+## Create API Key Endpoint Address
+
+https://api.vectara.io/v1/create-api-key
+
+### Request Headers
+
+abc
+
+### Request Body
+
+
+
+```json
+// code sample with fields explained if not obvious in previous paragraph
+
+```

--- a/www/docs/api-reference/api-keys/delete-api-key.md
+++ b/www/docs/api-reference/api-keys/delete-api-key.md
@@ -1,0 +1,26 @@
+---
+id: delete-api-key
+title: Delete API Key API Definition
+sidebar_label: Delete API Key API Definition
+---
+
+The Delete API key endpoint lets users delete one or more existing API keys. 
+This is necessary for managing the lifecycle and security of API keys.
+
+
+## Delete API Key Endpoint Address
+
+https://api.vectara.io/v1/delete-api-key
+
+### Request Headers
+
+abc
+
+### Request Body
+
+
+
+```json
+// code sample with fields explained if not obvious in previous paragraph
+
+```

--- a/www/docs/api-reference/api-keys/delete-api-key.md
+++ b/www/docs/api-reference/api-keys/delete-api-key.md
@@ -10,14 +10,19 @@ import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
 The Delete API key endpoint lets users delete one or more existing API keys. 
-This is necessary for managing the lifecycle and security of API keys.
-
+This capability is useful for managing the lifecycle and security of API keys 
+such as when they are no longer needed or when a key is compromised.
 
 ## Delete API Key Endpoint Address
 
 <Config v="names.product"/> exposes a REST endpoint at the following URL
 to index content into a corpus:
-<code>https://<Config v="domains.rest.indexing"/>/v1/create-api-key</code>
+<code>https://<Config v="domains.rest.indexing"/>/v1/delete-api-key</code>
+
+## Delete an API Key from the API Playground
+
+Check out our [interactive API Playground](/docs/rest-api/delete-api-key) that lets 
+experiment with this REST endpoint.
 
 ### Request Headers
 
@@ -29,10 +34,15 @@ headers:
 
 ### Request Body
 
-The request body includes...
+
+The Delete API Key request body requires the `keyID` of the API key you 
+want to delete.
 
 
 ```json
-// code sample with fields explained if not obvious in previous paragraph
-
+{
+  "keyId": [
+    "6o59jjft9o02jtga72pjfv3qpn"
+  ]
+}
 ```

--- a/www/docs/api-reference/api-keys/delete-api-key.md
+++ b/www/docs/api-reference/api-keys/delete-api-key.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
-The Delete API key endpoint lets users delete one or more existing API keys. 
+The Delete API Key endpoint lets you delete one or more existing API keys. 
 This capability is useful for managing the lifecycle and security of API keys 
 such as when they are no longer needed or when a key is compromised.
 
@@ -22,7 +22,7 @@ to index content into a corpus:
 ## Delete an API Key from the API Playground
 
 Check out our [interactive API Playground](/docs/rest-api/delete-api-key) that lets 
-experiment with this REST endpoint.
+you experiment with this REST endpoint to delete API keys from an account.
 
 ### Request Headers
 

--- a/www/docs/api-reference/api-keys/enable-api-key.md
+++ b/www/docs/api-reference/api-keys/enable-api-key.md
@@ -9,13 +9,22 @@ import TabItem from '@theme/TabItem';
 import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
-The Enable API Key endpoint lets you enable or disable specific API keys. 
+The Enable API Key endpoint lets you enable or disable specific API keys. You 
+can use this endpoint to temporarily disable access without deleting the key.
+
+This capability is useful for scenarios like maintenance windows. or when your 
+team no longer requires access to a specific corpus.
 
 ## Enable API Key REST Endpoint
 
 <Config v="names.product"/> exposes a REST endpoint at the following URL
 to index content into a corpus:
 <code>https://<Config v="domains.rest.indexing"/>/v1/enable-api-key</code>
+
+## Enable an API Key from the API Playground
+
+Check out our [interactive API Playground](/docs/rest-api/enable-api-key) that lets 
+you experiment with this REST endpoint to enable and disable API keys.
 
 ### Request Headers
 
@@ -28,3 +37,18 @@ headers:
 
 ### Request Body
 
+The Enable API Key request body requires the following parameters:
+* `keyID` - Specifies the ID of the API key
+* `enable` - Indicates whether to enable (`true`) or disable (`false`) the API key
+
+
+```json
+{
+  "keyEnablement": [
+    {
+      "keyId": "6o59jjft9o02jtga72pjfv3qpn",
+      "enable": true
+    }
+  ]
+}
+```

--- a/www/docs/api-reference/api-keys/enable-api-key.md
+++ b/www/docs/api-reference/api-keys/enable-api-key.md
@@ -1,7 +1,7 @@
 ---
-id: delete-api-key
-title: Delete API Key API Definition
-sidebar_label: Delete API Key API Definition
+id: enable-api-key
+title: Enable API Key API Definition
+sidebar_label: Enable API Key API Definition
 ---
 
 import Tabs from '@theme/Tabs';
@@ -9,15 +9,13 @@ import TabItem from '@theme/TabItem';
 import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
-The Delete API key endpoint lets users delete one or more existing API keys. 
-This is necessary for managing the lifecycle and security of API keys.
+The Enable API Key endpoint lets you enable or disable specific API keys. 
 
-
-## Delete API Key Endpoint Address
+## Enable API Key REST Endpoint
 
 <Config v="names.product"/> exposes a REST endpoint at the following URL
 to index content into a corpus:
-<code>https://<Config v="domains.rest.indexing"/>/v1/create-api-key</code>
+<code>https://<Config v="domains.rest.indexing"/>/v1/enable-api-key</code>
 
 ### Request Headers
 
@@ -27,12 +25,6 @@ headers:
 * `customer_id` is the customer ID to use for the request.
 * An JWT token as your authentication method
 
+
 ### Request Body
 
-The request body includes...
-
-
-```json
-// code sample with fields explained if not obvious in previous paragraph
-
-```

--- a/www/docs/api-reference/api-keys/list-api-keys.md
+++ b/www/docs/api-reference/api-keys/list-api-keys.md
@@ -1,0 +1,27 @@
+---
+id: list-api-keys
+title: List API Keys API Definition
+sidebar_label: List API Keys API Definition
+---
+
+The List API keys endpoint lists all API keys created under a specific
+customer ID. This can provide insights into key usage and status and help you
+manage the lifecycle and security of your API keys.
+
+
+## List API Keys Endpoint Address
+
+https://api.vectara.io/v1/list-api-keys
+
+### Request Headers
+
+abc
+
+### Request Body
+
+
+
+```json
+// code sample with fields explained if not obvious in previous paragraph
+
+```

--- a/www/docs/api-reference/api-keys/list-api-keys.md
+++ b/www/docs/api-reference/api-keys/list-api-keys.md
@@ -4,24 +4,33 @@ title: List API Keys API Definition
 sidebar_label: List API Keys API Definition
 ---
 
-The List API keys endpoint lists all API keys created under a specific
-customer ID. This can provide insights into key usage and status and help you
+The List API keys endpoint lists all existng API keys for your customer ID. 
+It also shows what corpora are accessed by these keys and also with what permissions.
+
+This can provide insights into key usage and status and help you
 manage the lifecycle and security of your API keys.
 
 
 ## List API Keys Endpoint Address
 
-https://api.vectara.io/v1/list-api-keys
+<Config v="names.product"/> exposes a REST endpoint at the following URL
+to index content into a corpus:
+<code>https://<Config v="domains.rest.indexing"/>/v1/list-api-keys</code>
 
 ### Request Headers
 
-abc
+To interact with the List API Keys service via REST calls, you need the following 
+headers:
+
+* `customer_id` is the customer ID to use for the request.
+* An JWT token as your authentication method
+
 
 ### Request Body
 
-
+The request body includes...
 
 ```json
-// code sample with fields explained if not obvious in previous paragraph
+// tbd
 
 ```

--- a/www/docs/api-reference/api-keys/list-api-keys.md
+++ b/www/docs/api-reference/api-keys/list-api-keys.md
@@ -4,10 +4,16 @@ title: List API Keys API Definition
 sidebar_label: List API Keys API Definition
 ---
 
-The List API keys endpoint lists all existng API keys for your customer ID. 
-It also shows what corpora are accessed by these keys and also with what permissions.
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import {Config} from '@site/docs/definitions.md';
+import {vars} from '@site/static/variables.json';
 
-This can provide insights into key usage and status and help you
+The List API keys endpoint lists all existng API keys for a customer ID. 
+It also shows what corpora are accessed by these keys and with what 
+permissions.
+
+This capability can provide insights into key usage and status and help you
 manage the lifecycle and security of your API keys.
 
 
@@ -17,10 +23,16 @@ manage the lifecycle and security of your API keys.
 to index content into a corpus:
 <code>https://<Config v="domains.rest.indexing"/>/v1/list-api-keys</code>
 
+## List the API Keys from the API Playground
+
+Check out our [interactive API Playground](/docs/rest-api/list-api-keys) that lets 
+you experiment with this REST endpoint to list API keys in your account.
+
+
 ### Request Headers
 
-To interact with the List API Keys service via REST calls, you need the following 
-headers:
+To interact with the List API Keys service via REST calls, you need the 
+following headers:
 
 * `customer_id` is the customer ID to use for the request.
 * An JWT token as your authentication method
@@ -28,9 +40,17 @@ headers:
 
 ### Request Body
 
-The request body includes...
+The List API Keys request body requires the following parameters:
+* `numResults` - Specifies the maximum number of results to return.
+* `pageKey` Specifies the page key that retrieves a specific page of results. 
+  If you want the first page, leave this field empty.
+* `readCorporaInfo`: Indicates whether to return the corpus name and ID 
+  associated with the API keys.
 
 ```json
-// tbd
-
+{
+  "numResults": 0,
+  "pageKey": "1",
+  "readCorporaInfo": true
+}
 ```

--- a/www/docs/api-reference/api-keys/list-api-keys.md
+++ b/www/docs/api-reference/api-keys/list-api-keys.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
-The List API keys endpoint lists all existng API keys for a customer ID. 
+The List API Keys endpoint lists all existing API keys for a customer ID. 
 It also shows what corpora are accessed by these keys and with what 
 permissions.
 
@@ -26,7 +26,7 @@ to index content into a corpus:
 ## List the API Keys from the API Playground
 
 Check out our [interactive API Playground](/docs/rest-api/list-api-keys) that lets 
-you experiment with this REST endpoint to list API keys in your account.
+you experiment with this REST endpoint to list API keys in an account.
 
 
 ### Request Headers

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -303,16 +303,6 @@ module.exports = {
             'api-reference/admin-apis/admin',
             {
               type: 'category',
-              label: 'API Key APIs',
-              items: [
-                'api-reference/api-keys/create-api-key',
-                'api-reference/api-keys/delete-api-key',
-                'api-reference/api-keys/list-api-keys',
-                'api-reference/api-keys/enable-api-key',
-              ]
-            },
-            {
-              type: 'category',
               label: 'Create Corpus',
               items: [
                 'api-reference/admin-apis/create-corpus',
@@ -360,6 +350,16 @@ module.exports = {
                     'getting-started-samples/rest_reset_corpus.py'
                   ]
                 }
+              ]
+            },
+            {
+              type: 'category',
+              label: 'API Key Management APIs',
+              items: [
+                'api-reference/api-keys/create-api-key',
+                'api-reference/api-keys/delete-api-key',
+                'api-reference/api-keys/list-api-keys',
+                'api-reference/api-keys/enable-api-key',
               ]
             },
           ],

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -303,6 +303,15 @@ module.exports = {
             'api-reference/admin-apis/admin',
             {
               type: 'category',
+              label: 'API Key APIs',
+              items: [
+                'api-reference/api-keys/create-api-key',
+                'api-reference/api-keys/delete-api-key',
+                'api-reference/api-keys/list-api-keys',
+              ]
+            },
+            {
+              type: 'category',
               label: 'Create Corpus',
               items: [
                 'api-reference/admin-apis/create-corpus',

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -308,6 +308,7 @@ module.exports = {
                 'api-reference/api-keys/create-api-key',
                 'api-reference/api-keys/delete-api-key',
                 'api-reference/api-keys/list-api-keys',
+                'api-reference/api-keys/enable-api-key',
               ]
             },
             {


### PR DESCRIPTION
These topics will be the long form topics for the create, delete, list, and enable API key endpoints. They will be finalized after the protos are merged and API Playground is updated and I plan to release them both the same day.