### PR TITLE
Improve the Index API Definition topic

### DIFF
--- a/www/docs/api-reference/indexing-apis/core_indexing.md
+++ b/www/docs/api-reference/indexing-apis/core_indexing.md
@@ -9,31 +9,160 @@ import TabItem from '@theme/TabItem';
 import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
-The low-level indexing API provides low-level access to the semantic indexing
-capabilities of the platform. It is reserved for advanced use cases and
-normal users should use the [Standard API](indexing).
+The Low-level Indexing API provides low-level access to the semantic indexing 
+capabilities of the platform. The Standard Indexing API organizes documents 
+into sections that have IDs, titles, and descriptions, like traditional, 
+hierarchical document structures. This Low-level Indexing API differs by 
+focusing on document `parts` which allow for specific text and context 
+definitions within 
+a document.
 
-## Full Low-level Indexing Definition
+This more granular control over documents enables you to tailor your indexing 
+strategies. This API is reserved for advanced use cases and normal 
+users should use the [Standard API](indexing).
 
-The full definition of the gRPC interface is covered below.
+:::tip
 
-### Low-level Indexing Service
+Check out our [**interactive API Playground**](/docs/rest-api/core-index) that lets you experiment 
+with this endpoint to index documents from your browser.
+
+:::
+
+### Low-Level Index Document Request and Response
 
 The indexing service operates by accepting individual documents or messages to 
 be indexed. In a short period of time, generally a few minutes, the new 
-content will become available in the search index.
+content becomes available in the search index. This index request requires the 
+following parameters:
 
-The following shows the definition of the service:
+* Customer ID 
+* Corpus ID
+* Document object
+
+The reply from the server consists of nothing yet. Note that the reply does not
+block. In other words, the information in the request is not yet available in
+the index when the RPC returns.
+
+## Document Container
+
+The `document` object is a container of related textual items that are indexed. 
+This object has a `document_id`, which must be unique among all the documents in
+the same corpus. It may optionally define `metadata_json`.
+
+Two fields, `default_part_context` and `custom_dims` (Scale only), provide 
+default values for the corresponding sub-document fields, should they fail to 
+define either of these explicitly.
+
+Most importantly, `parts` defines the actual text items to be indexed.
+
+## Documents Parts
+
+The document part is the atomic unit of <Config v="names.product"/>. Every 
+part is added to the index, and when search results are returned, each result 
+is a document part:
+* Text
+* Context
+* Metadata
+* Custom Dimensions
+
+The `text` field defines the text. This should generally be a sentence: it
+should not be shorter, but may be longer, up to the length of an entire
+paragraph, although performance may suffer.
+
+The `context` defines the context of the text. It may include any additional
+textual information that helps in disambiguating the meaning. For instance, it
+may include the preceding or following paragraphs, the chapter title, or the
+document title.
+
+The part metadata, held in `metadata_json`, is returned with the document part
+in search query results. For example, it can contain information that links the
+item to records in other systems.
+
+Finally, `custom_dims` allows you to specify additional factors that can be
+used at query time to control the ranking of results. The dimensions must be
+defined ahead of time for the corpus, or else they'll be ignored.
+
+## REST Example
+
+### Low-level Indexing REST Endpoint
+
+<Config v="names.product"/> exposes a REST endpoint at the following URL
+to index content into a corpus:
+<code>https://<Config v="domains.rest.indexing"/>/v1/core-index</code>
 
 
-```protobuf
-service CoreIndexService {
-  // Adds a document to the corpus.
-  rpc Index(IndexCoreDocumentRequest) returns (IndexCoreDocumentResponse) {}
+### Low-level Indexing Request and Response
+
+The request body provides the following parameters:
+
+* `customerID`
+* `corpusID`
+* `document` object containing the `documentID`, `metadataJson`, and contextual `parts`
+
+```json
+{
+  "customerId": "123456789",
+  "corpusId": "8",
+  "document": {
+    "documentId": "Research_Doc_1",
+    "metadataJson": "{\"category\":\"Research Papers\"}",
+    "parts": [
+      {
+        "text": "Introduction to Quantum Computing",
+        "context": "Quantum Computing Overview that summarizes the main points of the paper's purpose",
+        "metadataJson": "{\"section\":\"Introduction\"}",
+        "customDims": [
+          {
+            "name": "relevance",
+            "value": 10
+          }
+        ]
+      },
+      {
+        "text": "Quantum Entanglement and Superposition",
+        "context": "Chapter 1: Key Quantum Computing Concepts",
+        "metadataJson": "{\"section\":\"Chapter 1\"}",
+        "customDims": [
+          {
+            "name": "complexity",
+            "value": 15
+          }
+        ]
+      }
+      // Continue with additional parts that you want indexed
+    ],
+    "defaultPartContext": "Quantum Computing Research Study",
+    "customDims": [
+      {
+        "name": "difficulty",
+        "value": 6
+      }
+    ]
+  }
 }
 ```
+The response from the server includes a status code and the amount of quota 
+consumed:
 
-### Document Index Request
+```json
+{
+  "status": {
+    "code": "OK",
+    "statusDetail": ""
+  },
+  "quotaConsumed": {
+    "numChars": "1572",
+    "numMetadataChars": "332"
+  }
+}
+
+```
+
+## gRPC Example
+
+You can find the full Low-level Indexing gRPC definition at [indexing_core.proto](https://github.com/vectara/protos/blob/main/indexing_core.proto).
+
+### Index Document Request and Response
 
 A request to add data into a corpus consists of three key pieces of information:
 the customer ID, the corpus ID, and the data itself, represented as a
@@ -53,22 +182,7 @@ The reply from the server consists of nothing yet. Note that the reply does not
 block. In other words, the information in the request is not yet available in
 the index when the RPC returns.
 
-```protobuf
-message IndexDocumentReply {
-}
-```
-
-### Core Document Container
-
-The document is a container of related textual items that are indexed. It
-defines an ID, `document_id`, which must be unique among all the documents in
-the same corpus. It may optionally define metadata, `metadata_json`.
-
-Two fields, `default_part_context` and `custom_dims`, provide default values
-for the corresponding sub-document fields, should they fail to define either
-of these explicitly.
-
-Most importantly, `parts` defines the actual text items to be indexed.
+### Document Container Format
 
 ```protobuf
 // A document to index.
@@ -87,38 +201,18 @@ message CoreDocument {
   // representation of all parts.
   repeated CustomDimension custom_dims = 5;
 }
-}
 ```
 
-### Core Document Part
-
-The document part is the atomic unit of <Config v="names.product"/>. Every part is added to
-the index, and when search results are returned, each result is a document part.
-
-The `text` field defines the text. This should generally be a sentence: it
-should not be shorter, but may be longer, up to the length of an entire
-paragraph, although performance may suffer.
-
-The `context` defines the context of the text. It may include any additional
-textual information that helps in disambiguating the meaning. For instance, it
-may include the preceding or following paragraphs, the chapter title, or the
-document title.
-
-The part metadata, held in `metadata_json`, is returned with the document part
-in search query results. It can contain, for example, information that links the
-item to records in other systems.
-
-Finally, `custom_dims` allows you to specify additional factors that can be
-used at query time to control the ranking of results. The dimensions must be
-defined ahead of time for the corpus, or else they'll be ignored.
+### Part within the Document
 
 ```protobuf
+// Part of a document. A document consists of several such parts.
 message CoreDocumentPart {
-  // A part of the document, such as a sentence.
+  // A part of the document. e.g., a sentence.
   string text = 1;
   // Context of the part.
   string context = 2;
-  // Metadata about this part of the document. This metadata should be a json string.
+  // Metadata about this part of the document. This should be a json string.
   // It is passed through the system, without being used at indexing time. It
   // can be retrieved at query time.
   string metadata_json = 3;

--- a/www/docs/api-reference/indexing-apis/core_indexing.md
+++ b/www/docs/api-reference/indexing-apis/core_indexing.md
@@ -10,16 +10,15 @@ import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
 The Low-level Indexing API provides low-level access to the semantic indexing 
-capabilities of the platform. The Standard Indexing API organizes documents 
+capabilities of the <Config v="names.product"/> platform. It focuses on document `parts` which allow for 
+specific text and context definitions within a document. This approach differs 
+from the [Standard Indexing API](indexing) which organizes documents 
 into sections that have IDs, titles, and descriptions, like traditional, 
-hierarchical document structures. This Low-level Indexing API differs by 
-focusing on document `parts` which allow for specific text and context 
-definitions within 
-a document.
+hierarchical document structures. 
 
 This more granular control over documents enables you to tailor your indexing 
-strategies. This API is reserved for advanced use cases and normal 
-users should use the [Standard API](indexing).
+strategies. The Low-level Indexing API is reserved for advanced use cases and 
+normal users should use the Standard Indexing API.
 
 :::tip
 
@@ -28,9 +27,9 @@ with this endpoint to index documents from your browser.
 
 :::
 
-### Low-Level Index Document Request and Response
+### Low-level Index Document Request and Response
 
-The indexing service operates by accepting individual documents or messages to 
+The low-level indexing service accepts individual documents or messages to 
 be indexed. In a short period of time, generally a few minutes, the new 
 content becomes available in the search index. This index request requires the 
 following parameters:
@@ -39,33 +38,27 @@ following parameters:
 * Corpus ID
 * Document object
 
-The reply from the server consists of nothing yet. Note that the reply does not
-block. In other words, the information in the request is not yet available in
-the index when the RPC returns.
+The response includes a `status` message and a `StorageQuota` message
+indicating how much quota was consumed.
 
-## Document Container
+## Document Container Definition
 
-The `document` object is a container of related textual items that are indexed. 
+The `document` object contains the related textual items that are indexed. 
 This object has a `document_id`, which must be unique among all the documents in
 the same corpus. It may optionally define `metadata_json`.
 
-Two fields, `default_part_context` and `custom_dims` (Scale only), provide 
+The two fields `default_part_context` and `custom_dims` (Scale only) provide 
 default values for the corresponding sub-document fields, should they fail to 
 define either of these explicitly.
 
-Most importantly, `parts` defines the actual text items to be indexed.
+### Parts within a Document
 
-## Documents Parts
-
-The document part is the atomic unit of <Config v="names.product"/>. Every 
+Most importantly, `parts` defines the actual text items that you want to index.
+The document *part* is the atomic unit of <Config v="names.product"/>. Every 
 part is added to the index, and when search results are returned, each result 
-is a document part:
-* Text
-* Context
-* Metadata
-* Custom Dimensions
+is a document part.
 
-The `text` field defines the text. This should generally be a sentence: it
+The `text` field defines the text and should generally be a sentence. It
 should not be shorter, but may be longer, up to the length of an entire
 paragraph, although performance may suffer.
 

--- a/www/docs/api-reference/indexing-apis/core_indexing.md
+++ b/www/docs/api-reference/indexing-apis/core_indexing.md
@@ -6,8 +6,9 @@ sidebar_label: Low-level Indexing API Definition
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import {Config} from '@site/docs/definitions.md';
+import CodeBlock from '@theme/CodeBlock';
 import {vars} from '@site/static/variables.json';
+import {Config} from '@site/docs/definitions.md';
 
 The Low-level Indexing API provides low-level access to the semantic indexing 
 capabilities of the <Config v="names.product"/> platform. It focuses on document `parts` which allow for 

--- a/www/docs/api-reference/indexing-apis/deleting_documents.md
+++ b/www/docs/api-reference/indexing-apis/deleting_documents.md
@@ -9,30 +9,36 @@ import TabItem from '@theme/TabItem';
 import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
-## Delete Documents Endpoint Address
+The Delete Documents API lets you delete a document from a corpus.
 
-<Config v="names.product"/> exposes a REST endpoint at the following URL
-to delete content from a corpus:
-<code>https://<Config v="domains.rest.indexing"/>/v1/delete-doc</code>
+:::tip
 
-### Request Headers
+Check out our [**interactive API Playground**](/docs/rest-api/delete-doc) that enables you
+to experiment with this REST endpoint. You can delete a file from a corpus
+directly from your browser or copy the curl for your command line.
 
-To interact with the Index service via REST calls, you need the following 
-headers:
+:::
 
-* `customer_id` is the customer ID to use for the request.
-* An API Key or JWT token is your authentication method
-* (Optional) `grpc-timeout` lets you specify how long to wait for the calls 
-  that have the potential to take longer to process. We recommend 
-  `-H "grpc-timeout: 30S"`
-
-### Request Body
+### Delete Document Request and Response
 
 A request to delete a document from a corpus consists of three key pieces of 
 information:
 * `customer_id`
 * `corpus_id`
 * `document_id`
+
+The reply on successful deletion is `{}`.
+
+
+## REST Example
+
+### Delete Documents Endpoint Address
+
+<Config v="names.product"/> exposes a REST endpoint at the following URL
+to delete content from a corpus:
+<code>https://<Config v="domains.rest.indexing"/>/v1/delete-doc</code>
+
+### Delete Document Request and Response
 
 ```json
 {
@@ -41,26 +47,24 @@ information:
   "documentId": "my_document.docx"
 }
 ```
+You get the following response:
+
+```json
+{}
+```
+To verify that the document no longer exists in the corpus, use the 
+List Documents endpoint.
+
+## gRPC Example
+
+You can find the Delete Document gRPC definition at [common.proto](https://github.com/vectara/protos/blob/main/common.proto).
 
 The reply from the server consists of nothing yet. Note that while the 
 operation is not completely synchronous (the document may still be returned 
 in query results), the platform typically removes the document within a few 
 seconds, though it may take longer for Growth accounts.
 
-<!-- Will probably remove the following and replace with REST
-
-### gRPC Status Codes
-
-The server returns the following [gRPC status codes](https://grpc.github.io/grpc/core/md_doc_statuscodes.html):
-
-- `INTERNAL`: An internal error code indicates a failure inside the platform, 
-  and an immediate retry may not succeed.
-- `UNAVAILABLE`: The service is temporarily unavailable, and the operation should be 
-  retried, preferably with a backoff. 
-  
-  Note that the deletion operation is idempotent, so it is fine to re-apply.
-
-### Delete a Document gRPC Example
+### Java and Python Examples
 
 The code snippet belows illustrates how to delete a document from a corpus in Java or Python. For information
 on how to get the call credentials and metadata, please consult
@@ -111,4 +115,15 @@ indexingStub.withCallCredentials(credentials(tokenSupplier.get().getOrDie()))
 </TabItem>
 </Tabs>
 
--->
+### gRPC Status Codes
+
+The server returns the following [gRPC status codes](https://grpc.github.io/grpc/core/md_doc_statuscodes.html):
+
+- `INTERNAL`: An internal error code indicates a failure inside the platform, 
+  and an immediate retry may not succeed.
+- `UNAVAILABLE`: The service is temporarily unavailable, and the operation should be 
+  retried, preferably with a backoff. 
+  
+  :::note
+  The deletion operation is idempotent, so it is fine to re-apply.
+  :::

--- a/www/docs/api-reference/indexing-apis/deleting_documents.md
+++ b/www/docs/api-reference/indexing-apis/deleting_documents.md
@@ -13,7 +13,7 @@ The Delete Documents API lets you delete a document from a corpus.
 
 :::tip
 
-Check out our [**interactive API Playground**](/docs/rest-api/delete-doc) that enables you
+Check out our [**interactive API Playground**](/docs/rest-api/delete) that enables you
 to experiment with this REST endpoint. You can delete a file from a corpus
 directly from your browser or copy the curl for your command line.
 

--- a/www/docs/api-reference/indexing-apis/deleting_documents.md
+++ b/www/docs/api-reference/indexing-apis/deleting_documents.md
@@ -15,20 +15,30 @@ import {vars} from '@site/static/variables.json';
 to delete content from a corpus:
 <code>https://<Config v="domains.rest.indexing"/>/v1/delete-doc</code>
 
-This page describes the details of interacting with this endpoint.
+### Request Headers
 
-A request to delete a document from a corpus consists of three key pieces of information:
-the `customer_id`, the `corpus_id`, and the `document_id`.
+To interact with the Index service via REST calls, you need the following 
+headers:
 
-```protobuf
-// Request to delete a document from an index.
-message DeleteDocumentRequest {
-  // The Customer ID to issue the request for.
-  int64 customer_id = 1;
-  // The Corpus ID that contains the document.
-  int64 corpus_id = 2;
-  // The Document ID to be deleted.
-  string document_id = 3;
+* `customer_id` is the customer ID to use for the request.
+* An API Key or JWT token is your authentication method
+* (Optional) `grpc-timeout` lets you specify how long to wait for the calls 
+  that have the potential to take longer to process. We recommend 
+  `-H "grpc-timeout: 30S"`
+
+### Request Body
+
+A request to delete a document from a corpus consists of three key pieces of 
+information:
+* `customer_id`
+* `corpus_id`
+* `document_id`
+
+```json
+{
+  "customerId": "123456789",
+  "corpusId": 1,
+  "documentId": "my_document.docx"
 }
 ```
 
@@ -37,8 +47,11 @@ operation is not completely synchronous (the document may still be returned
 in query results), the platform typically removes the document within a few 
 seconds, though it may take longer for Growth accounts.
 
-The server returns [gRPC status codes](https://grpc.github.io/grpc/core/md_doc_statuscodes.html).
-For example:
+<!-- Will probably remove the following and replace with REST
+
+### gRPC Status Codes
+
+The server returns the following [gRPC status codes](https://grpc.github.io/grpc/core/md_doc_statuscodes.html):
 
 - `INTERNAL`: An internal error code indicates a failure inside the platform, 
   and an immediate retry may not succeed.
@@ -47,7 +60,7 @@ For example:
   
   Note that the deletion operation is idempotent, so it is fine to re-apply.
 
-### Delete a Document Example
+### Delete a Document gRPC Example
 
 The code snippet belows illustrates how to delete a document from a corpus in Java or Python. For information
 on how to get the call credentials and metadata, please consult
@@ -97,3 +110,5 @@ indexingStub.withCallCredentials(credentials(tokenSupplier.get().getOrDie()))
 
 </TabItem>
 </Tabs>
+
+-->

--- a/www/docs/api-reference/indexing-apis/file-upload/file_upload.md
+++ b/www/docs/api-reference/indexing-apis/file-upload/file_upload.md
@@ -3,24 +3,27 @@ id: file-upload
 title: File Upload API Definition
 ---
 
-import {Config} from '@site/docs/definitions.md';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CodeBlock from '@theme/CodeBlock';
 import {vars} from '@site/static/variables.json';
+import {Config} from '@site/docs/definitions.md';
 
 The File Upload API lets you extract text from existing, unstructured 
 documents in common file types like PDFs, Microsoft Word, Text, HTML, and 
 Markdown. The maximum file size supported by the server is 10 MB.
 
-We recommend the File Upload API when you do not need to define additional 
-user-supplied metadata beyond what is extracted by our platform. If you want 
-to attach metadata for optimizing searches made against your data, you can 
-[format your data as JSON](/docs/api-reference/indexing-apis/file-upload/format-for-upload).
+We recommend the File Upload API when you have not already written your own 
+extraction logic. You can attach user-defined metadata at the document level 
+for optimizing searches made against your data by 
+[formatting your data as JSON](/docs/api-reference/indexing-apis/file-upload/format-for-upload).
 
 :::tip
 
-* Check out our [interactive API Playground](/docs/rest-api/file-upload) that enables you
+* Check out our [**interactive API Playground**](/docs/rest-api/file-upload) that enables you
 to experiment with this REST endpoint. You can upload a file to a corpus 
 directly from your browser or copy the curl for your command line.
-* Review the [Supported File Types](/docs/api-reference/indexing-apis/file-upload/file-upload-filetypes)
+* Review the [**Supported File Types**](/docs/api-reference/indexing-apis/file-upload/file-upload-filetypes)
   for the most up-to-date list.
 
 :::
@@ -57,19 +60,10 @@ curl -L -X POST 'https://api.vectara.io/v1/upload?c=123456789&o=5' \
 -H 'x-api-key: zwt_123456' \
 -F 'file=@"/path/to/file"'
 ```
-## Set a Custom Document ID
-
-The `Content-Disposition` header lets you specify the Document ID of the file 
-that are uploading. Use the following format:
-
-`Content-Disposition: form-data; name="file"; filename="desired_doc_id"` 
-
-where `file` is the name of the file and `filename` is Document ID that you want 
-
 ### Attach Additional Metadata
 
-You can attach additional metadata to the file by specifying an additional
-`doc_metadata` form field, which can contain a JSON string:
+You can attach additional metadata to the file by specifying a `doc_metadata` 
+form field, which can contain a JSON string:
 
 ```json
 doc_metadata='{ "filesize": 1234 }'

--- a/www/docs/api-reference/indexing-apis/file-upload/file_upload.md
+++ b/www/docs/api-reference/indexing-apis/file-upload/file_upload.md
@@ -6,32 +6,41 @@ title: File Upload API Definition
 import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
+The File Upload API lets you extract text from existing, unstructured 
+documents in common file types like PDFs, Microsoft Word, Text, HTML, and 
+Markdown. The maximum file size supported by the server is 10 MB.
+
+We recommend the File Upload API when you do not need to define additional 
+user-supplied metadata beyond what is extracted by our platform. If you want 
+to attach metadata for optimizing searches made against your data, you can 
+[format your data as JSON](/docs/api-reference/indexing-apis/file-upload/format-for-upload).
+
+:::tip
+
+* Check out our [interactive API Playground](/docs/rest-api/file-upload) that enables you
+to experiment with this REST endpoint. You can upload a file to a corpus 
+directly from your browser or copy the curl for your command line.
+* Review the [Supported File Types](/docs/api-reference/indexing-apis/file-upload/file-upload-filetypes)
+  for the most up-to-date list.
+
+:::
+
 ## File Upload REST Endpoint
 
 <Config v="names.product"/> exposes an HTTP endpoint at the following URL
 to upload and index documents into a corpus:
 <code>https://<Config v="domains.rest.indexing"/>/v1/upload</code>
 
-### Index Request Headers
-
-To interact with the File Upload endpoint, you need the following 
-headers:
-
-* An `x-api-key` or JWT token as your authentication method
-* (Optional) `grpc-timeout` lets you specify how long to wait for the calls 
-  that have the potential to take longer to process. We recommend 
-  `-H "grpc-timeout: 30S"`
-
 ## File Upload Request Details
 
 The File Upload endpoint expects an `multipart/form-data` `POST` request that includes the
 following HTTP parameters:
 
-1. (Required) `c`: `customer_id`.
+* `c` - Specifies the `customer_id`.
 
-2. (Required) `o`: `corpus_id` into which the document should be indexed.
+* `o` - Specifies the `corpus_id` into which the document should be indexed.
 
-3. (Optional) `d`: If set to `true`, the server returns the extracted
+* (Optional) `d`: If set to `true`, the server returns the extracted
 document that was indexed. 
 
   Use this parameter when uploading a raw file (pdf, docx) instead of a file 
@@ -41,15 +50,13 @@ document that was indexed.
 Apart from these parameters, the servers expect a valid JWT Token in the HTTP
 headers.
 
-## Upload a File from the API Playground
-
-Check out our [interactive API Playground](/docs/rest-api/file-upload) that enables you
-to experiment with this REST endpoint. You can upload a file to a corpus 
-directly from your browser or copy the curl for your command line.
-
-### Maximum File Upload Size
-
-The maximum file size supported by the server is 10 MB.
+```json
+curl -L -X POST 'https://api.vectara.io/v1/upload?c=123456789&o=5' \
+-H 'Content-Type: multipart/form-data' \
+-H 'Accept: application/json' \
+-H 'x-api-key: zwt_123456' \
+-F 'file=@"/path/to/file"'
+```
 
 ### Attach Additional Metadata
 

--- a/www/docs/api-reference/indexing-apis/file-upload/file_upload.md
+++ b/www/docs/api-reference/indexing-apis/file-upload/file_upload.md
@@ -57,6 +57,14 @@ curl -L -X POST 'https://api.vectara.io/v1/upload?c=123456789&o=5' \
 -H 'x-api-key: zwt_123456' \
 -F 'file=@"/path/to/file"'
 ```
+## Set a Custom Document ID
+
+The `Content-Disposition` header lets you specify the Document ID of the file 
+that are uploading. Use the following format:
+
+`Content-Disposition: form-data; name="file"; filename="desired_doc_id"` 
+
+where `file` is the name of the file and `filename` is Document ID that you want 
 
 ### Attach Additional Metadata
 

--- a/www/docs/api-reference/indexing-apis/indexing.md
+++ b/www/docs/api-reference/indexing-apis/indexing.md
@@ -13,10 +13,17 @@ The first step in using <Config v="names.product"/> is to index a set of related
 documents or content into a corpus. Indexing a document enables you to make data
 available for search and retrieval more efficiently.
 
-Our indexing focuses on transforming unstructured or semi-structured data into 
-a structured format that enables the data to become more easily
-searchable. This endpoint supports a variety of data formats by allowing for 
-detailed specification of document attributes and metadata.
+Our indexing transforms unstructured or semi-structured data into 
+a structured format that enables the data to become easily
+searchable in just a few seconds. We support a variety of data formats by 
+allowing for detailed specification of document attributes and metadata.
+
+The [document object](#document-definition-in-vectara) encapsulates 
+the information about the document that you want to index. It typically 
+includes the `title`, `description`, and `metadata`. The core of the document 
+is also structured in `sections` that can include unique identifiers, titles, 
+strings, metadata,
+and so on.
 
 ## Standard Indexing REST Endpoint
 
@@ -32,7 +39,7 @@ headers:
 * `customer_id` is the customer ID to use for the request.
 * An API Key or JWT token is your authentication method
 * (Optional) `grpc-timeout` lets you specify how long to wait for the calls
-  that have the potential to take longer to process. We recommend
+  that have the potential to take longer to process. We recommend 30 seconds:
   `-H "grpc-timeout: 30S"`
 
 ### Index Request Body
@@ -76,10 +83,6 @@ and so on.
 }
 ```
 
-### Index REST Examples
-
-Check out our REST Index examples in [C#](/docs/getting-started-samples/RestIndexData.cs), [Java](/docs/getting-started-samples/RestIndex.java), [NodeJS](/docs/getting-started-samples/index_document.js), [PHP](/docs/getting-started-samples/indexDocument.php), and [Python](/docs/getting-started-samples/rest_index_document.py).
-
 ### Index REST Response
 
 The response from the server includes a status code and the amount of quota
@@ -99,8 +102,13 @@ consumed.
 }
 ```
 
-
 For the gRPC response, please see [IndexDocument](#index-document).
+
+## Index REST Examples
+
+Check out our REST Index examples in [C#](/docs/getting-started-samples/RestIndexData.cs), [Java](/docs/getting-started-samples/RestIndex.java), [NodeJS](/docs/getting-started-samples/index_document.js), [PHP](/docs/getting-started-samples/indexDocument.php), and [Python](/docs/getting-started-samples/rest_index_document.py).
+
+
 
 
 ## Full Standard Indexing gRPC Definition

--- a/www/docs/api-reference/indexing-apis/indexing.md
+++ b/www/docs/api-reference/indexing-apis/indexing.md
@@ -42,39 +42,40 @@ index. The Index request requires the following parameters:
 ```json
 
 {
-  "customerId": "string",
+  "customerId": "123456789",
   "corpusId": 1,
   "document": {
-    "documentId": "string",
-    "title": "string",
-    "description": "string",
-    "metadataJson": "string",
+    "documentId": "quantum_computing",
+    "title": "Advancements in Quantum Computing",
+    "description": "A research paper discussing recent advancements in quantum computing",
+    "metadataJson": "{\"field\":\"quantum computing\",\"publication_date\":\"2023-12-20\"}",
     "customDims": [
-      {
-        "name": "string",
-        "value": 0
-      }
+          {
+            "name": "citations",
+            "value": 10
+          }
     ],
     "section": [
       {
-        "id": 0,
-        "title": "string",
-        "text": "string",
-        "metadataJson": "string",
-        "customDims": [
-          {
-            "name": "string",
-            "value": 0
-          }
-        ],
+        "id": 1,
+        "title": "Introduction",
+        "text": "This introduction section provides an overview of quantum computing...",
+        "metadataJson": "{}",
+        "customDims": [],
         "section": [
-          null
+          // Another section with a unique ID, title, text, metadata, and so on
         ]
       }
     ]
   }
 }
 ```
+
+### Index REST Examples
+
+Check out our REST Index examples in [C#](/docs/getting-started-samples/RestIndexData.cs), [Java](/docs/getting-started-samples/RestIndex.java), [NodeJS](/docs/getting-started-samples/index_document.js), [PHP](/docs/getting-started-samples/indexDocument.php), and [Python](/docs/getting-started-samples/rest_index_document.py).
+
+### Index Response
 
 The response from the server includes a status code and the amount of quota
 consumed. For details, please see [IndexDocument](#index-document).

--- a/www/docs/api-reference/indexing-apis/indexing.md
+++ b/www/docs/api-reference/indexing-apis/indexing.md
@@ -306,26 +306,3 @@ message CustomDimension {
 For more information on how to use custom dimensions, refer to the
 [Custom Dimensions Usage Documentation](/docs/learn/semantic-search/add-custom-dimensions)
 
-## Delete Document
-
-Document deletion requires specifying the `corpus_id` and `document_id`. The
-`customer_id` is optional, and, if specified, must match the id of your
-account.
-
-```protobuf
-message DeleteDocumentRequest {
-  // The Customer ID to issue the request for.
-  int64 customer_id = 1;
-  // The Corpus ID that contains the document.
-  int64 corpus_id = 2;
-  // The Document ID to be deleted.
-  string document_id = 3;
-}
-```
-
-The server sends an empty reply in response.
-
-```protobuf
-message DeleteDocumentResponse {
-}
-```

--- a/www/docs/api-reference/indexing-apis/indexing.md
+++ b/www/docs/api-reference/indexing-apis/indexing.md
@@ -9,9 +9,14 @@ import TabItem from '@theme/TabItem';
 import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
-The first step in using <Config v="names.product"/> is to index a set of related documents
-or content into a corpus. Indexing a document enables you to make data
-available for search and retrieval.
+The first step in using <Config v="names.product"/> is to index a set of related 
+documents or content into a corpus. Indexing a document enables you to make data
+available for search and retrieval more efficiently.
+
+Our indexing focuses on transforming unstructured or semi-structured data into 
+a structured format that enables the data to become more easily
+searchable. This endpoint supports a variety of data formats by allowing for 
+detailed specification of document attributes and metadata.
 
 ## Standard Indexing REST Endpoint
 
@@ -39,32 +44,32 @@ index. The Index request requires the following parameters:
 * `corpusID`
 * `document` object
 
-```json
 
+Let's take a closer look at the [document object](#document-definition-in-vectara) which encapsulates 
+the information about the document to be indexed. It typically includes the 
+`title`, `description`, and `metadata`. The core of the document is also structured
+in `sections` that can include unique identifiers, titles, strings, metadata,
+and so on.
+
+```json
 {
-  "customerId": "123456789",
-  "corpusId": 1,
+  "customerId": 123456789,
+  "corpusId": 5,
   "document": {
-    "documentId": "quantum_computing",
-    "title": "Advancements in Quantum Computing",
-    "description": "A research paper discussing recent advancements in quantum computing",
-    "metadataJson": "{\"field\":\"quantum computing\",\"publication_date\":\"2023-12-20\"}",
-    "customDims": [
-          {
-            "name": "citations",
-            "value": 10
-          }
-    ],
+    "documentId": "issbn-9781405053976",
+    "title": "The Hitchhiker's Guide to the Galaxy",
+    "description": "A great book with the answer to life, the universe, and everything",
+    "metadataJson": "{\"author\": \"Douglas Adams\"}",
     "section": [
       {
-        "id": 1,
-        "title": "Introduction",
-        "text": "This introduction section provides an overview of quantum computing...",
-        "metadataJson": "{}",
-        "customDims": [],
-        "section": [
-          // Another section with a unique ID, title, text, metadata, and so on
-        ]
+        "title": "Intro",
+        "text": "Far out in the uncharted backwaters of the unfashionable end of the western spiral arm of the Galaxy lies a small unregarded yellow sun.",
+        "metadataJson": "{\"page\": 1}"
+      },
+      {
+        "title": "The answer",
+        "text": "The Answer to the Great Question ... Of Life, the Universe and Everything ... Is ... Forty-two.",
+        "metadataJson": "{\"speaker\": \"Deep Thought\"}"
       }
     ]
   }
@@ -75,22 +80,33 @@ index. The Index request requires the following parameters:
 
 Check out our REST Index examples in [C#](/docs/getting-started-samples/RestIndexData.cs), [Java](/docs/getting-started-samples/RestIndex.java), [NodeJS](/docs/getting-started-samples/index_document.js), [PHP](/docs/getting-started-samples/indexDocument.php), and [Python](/docs/getting-started-samples/rest_index_document.py).
 
-### Index Response
+### Index REST Response
 
 The response from the server includes a status code and the amount of quota
-consumed. For details, please see [IndexDocument](#index-document).
+consumed. 
+
+```json
+{
+  "status": {
+    "code": "OK",
+    "statusDetail": "",
+    "cause": null
+  },
+  "quotaConsumed": {
+    "numChars": "348",
+    "numMetadataChars": "469"
+  }
+}
+```
 
 
-Let's take a closer look at the document object which encapsulates the
-information about the document to be indexed. It typically includes the
-title, description, and metadata. The core of the document is also structured
-in sections that can include unique identifiers, titles, strings, metadata,
-and so on.
+For the gRPC response, please see [IndexDocument](#index-document).
 
 
 ## Full Standard Indexing gRPC Definition
 
-The full definition of the gRPC interface is covered below.
+The full definition of the gRPC interface is covered below, and you can always 
+find the latest definition at [indexing.proto](https://github.com/vectara/protos/blob/main/indexing.proto).
 
 ### Standard Indexing Service
 
@@ -126,6 +142,8 @@ message IndexDocumentRequest {
   ${vars['package.protobuf']}.indexing.Document document = 3;
 }
 `}</pre>
+
+### Index Response
 
 The reply from the server includes a status message and a `StorageQuota` message
 indicating how much quota was consumed, or, in the case of an `ALREADY_EXISTS`

--- a/www/docs/api-reference/indexing-apis/indexing.md
+++ b/www/docs/api-reference/indexing-apis/indexing.md
@@ -10,233 +10,70 @@ import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
 The first step in using <Config v="names.product"/> is to index a set of related 
-documents or content into a corpus. Indexing a document enables you to make data
-available for search and retrieval more efficiently.
+documents or content into a corpus. Indexing a document enables you to make 
+data available for search and retrieval more efficiently. 
 
-Our indexing transforms unstructured or semi-structured data into 
-a structured format that enables the data to become easily
-searchable in just a few seconds. We support a variety of data formats by 
-allowing for detailed specification of document attributes and metadata.
+Our standard indexing transforms unstructured or semi-structured data into a 
+format that enables the data to become easily searchable in just a couple of 
+seconds. We also support a variety of data formats by allowing you to specify 
+multiple document attributes and metadata.
 
-The [document object](#document-definition-in-vectara) encapsulates 
-the information about the document that you want to index. It typically 
-includes the `title`, `description`, and `metadata`. The core of the document 
-is also structured in `sections` that can include unique identifiers, titles, 
-strings, metadata,
-and so on.
+:::tip
 
-## Standard Indexing REST Endpoint
+* Check out our [**interactive API Playground**](/docs/rest-api/index) that lets you experiment 
+with this endpoint to index documents from your browser.
+* We also provide REST Index examples in in [C#](/docs/getting-started-samples/RestIndexData.cs), [Java](/docs/getting-started-samples/RestIndex.java), [NodeJS](/docs/getting-started-samples/index_document.js), [PHP](/docs/getting-started-samples/indexDocument.php), and [Python](/docs/getting-started-samples/rest_index_document.py).
 
-<Config v="names.product"/> exposes a REST endpoint at the following URL
-to index content into a corpus:
-<code>https://<Config v="domains.rest.indexing"/>/v1/index</code>
+:::
 
-### Index Request Headers
+### Index Document Request and Response
 
-To interact with the Index service via REST calls, you need the following
-headers:
+The request that adds data into a corpus provides essential information about 
+the document you want to index. A document is a piece of coherent textual 
+matter. This index request requires the following parameters:
 
-* `customer_id` is the customer ID to use for the request.
-* An API Key or JWT token is your authentication method
-* (Optional) `grpc-timeout` lets you specify how long to wait for the calls
-  that have the potential to take longer to process. We recommend 30 seconds:
-  `-H "grpc-timeout: 30S"`
+* Customer ID 
+* Corpus ID
+* Document object
 
-### Index Request Body
+The response includes a `status` message and a `StorageQuota` message
+indicating how much quota was consumed. An `ALREADY_EXISTS` status code 
+indicates how much quota would have been consumed.
 
-The request body provides essential information about the document you want to
-index. The Index request requires the following parameters:
-
-* `customerID`
-* `corpusID`
-* `document` object
-
-
-Let's take a closer look at the [document object](#document-definition-in-vectara) which encapsulates 
-the information about the document to be indexed. It typically includes the 
-`title`, `description`, and `metadata`. The core of the document is also structured
-in `sections` that can include unique identifiers, titles, strings, metadata,
-and so on.
-
-```json
-{
-  "customerId": 123456789,
-  "corpusId": 5,
-  "document": {
-    "documentId": "issbn-9781405053976",
-    "title": "The Hitchhiker's Guide to the Galaxy",
-    "description": "A great book with the answer to life, the universe, and everything",
-    "metadataJson": "{\"author\": \"Douglas Adams\"}",
-    "section": [
-      {
-        "title": "Intro",
-        "text": "Far out in the uncharted backwaters of the unfashionable end of the western spiral arm of the Galaxy lies a small unregarded yellow sun.",
-        "metadataJson": "{\"page\": 1}"
-      },
-      {
-        "title": "The answer",
-        "text": "The Answer to the Great Question ... Of Life, the Universe and Everything ... Is ... Forty-two.",
-        "metadataJson": "{\"speaker\": \"Deep Thought\"}"
-      }
-    ]
-  }
-}
-```
-
-### Index REST Response
-
-The response from the server includes a status code and the amount of quota
-consumed. 
-
-```json
-{
-  "status": {
-    "code": "OK",
-    "statusDetail": "",
-    "cause": null
-  },
-  "quotaConsumed": {
-    "numChars": "348",
-    "numMetadataChars": "469"
-  }
-}
-```
-
-For the gRPC response, please see [IndexDocument](#index-document).
-
-## Index REST Examples
-
-Check out our REST Index examples in [C#](/docs/getting-started-samples/RestIndexData.cs), [Java](/docs/getting-started-samples/RestIndex.java), [NodeJS](/docs/getting-started-samples/index_document.js), [PHP](/docs/getting-started-samples/indexDocument.php), and [Python](/docs/getting-started-samples/rest_index_document.py).
-
-
-
-
-## Full Standard Indexing gRPC Definition
-
-The full definition of the gRPC interface is covered below, and you can always 
-find the latest definition at [indexing.proto](https://github.com/vectara/protos/blob/main/indexing.proto).
-
-### Standard Indexing Service
-
-The indexing service operates by accepting individual documents or messages to
-be indexed. The content will become available in the search index, generally
-within a second or two.
-
-### Indexing Service Definition
-
-The following shows the definition of the service:
-
-
-```protobuf
-service IndexService {
-  // Adds a document to the corpus.
-  rpc Index(IndexDocumentRequest) returns (IndexDocumentResponse) {}
-
-  // Deletes a document from the corpus.
-  rpc Delete(DeleteDocumentRequest) returns (DeleteDocumentResponse) {}
-}
-```
-
-## Index Document
-
-A request to add data into a corpus consists of three key pieces of information:
-the `customer_id`, the `corpus_id`, and the data itself, represented as a
-**Document** message.
-
-<pre>{`
-message IndexDocumentRequest {
-  int64 customer_id = 1;
-  int64 corpus_id = 2;
-  ${vars['package.protobuf']}.indexing.Document document = 3;
-}
-`}</pre>
-
-### Index Response
-
-The reply from the server includes a status message and a `StorageQuota` message
-indicating how much quota was consumed, or, in the case of an `ALREADY_EXISTS`
-status code, how much quota would have been consumed.
-
-Note that the reply does not block. In other words, the information in the
-request is not necessarily available in the index when the RPC returns. In most
-cases, though, it becomes available within a second.
-
-```protobuf
-message IndexDocumentResponse {
-  // If ALREADY_EXISTS, it means the document was already indexed, and no new
-  // quota was consumed.
-  Status status = 1;
-
-  // The storage quota needed for the document indexed in the request.
-  // If "status" is ALREADY_EXISTS, it means that the document was already in
-  // the index prior to this request. In such cases, quota is not consumed again
-  // and the value in this field represents the quota consumed when the document
-  // was indexed the first time.
-  StorageQuota quota_consumed = 2;
-}
-```
+:::note
 
 The storage quota object returns the number of characters consumed and the number
 of metadata characters consumed. The total quota consumed is simply the sum of
 both values.
 
-```protobuf
-message StorageQuota {
-  // The number of chars from the document that consumed the storage quota.
-  int64 num_chars = 1;
-  // The number of chars in the metadata of the document that consumed the
-  // storage quota.
-  int64 num_metadata_chars = 2;
-}
-```
+:::
 
-### Document Definition in Vectara
+## Document Definition
 
-A document is a piece of coherent textual matter. It defines an ID,
-`document_id`, which must be unique among all the documents in
-the same corpus. It may optionally specify a `title` and a `description`,
-as well as metadata in `metadata_json`.
+A `document` object encapsulates the information about the data that you want to 
+index. This object has a `document_id` which must be unique among all the 
+documents in the same corpus. The document may optionally speciify a `title`, 
+`description`, and `metadata`. The core of the document is also structured in 
+`sections` that can include unique identifiers, titles, strings, metadata, and 
+so on.
 
 The `custom_dims` field provides default values for the corresponding
-section fields, should they fail to define them explicitly.
-
-Most importantly, `section` defines the actual textual matter.
-
-```protobuf
-message Document {
-  // Client assigned document ID to this document.
-  string document_id = 1;
-  // The title of the document.
-  string title = 2;
-  // An optional description for the document.
-  string description = 3;
-  // Metadata about the document. This should be a json string, and it can be
-  // retrieved at query time.
-  string metadata_json = 4;
-  // A list of custom dimension values that are included in the generated
-  // representation of all sections.
-  repeated CustomDimension custom_dims = 5;
-
-  // The actual content of the document, structured as a repeating list
-  // of sections.
-  repeated Section section = 10;
-}
-
-```
+section fields, should they fail to define them explicitly. Most importantly, 
+`section` defines the actual textual matter.
 
 ### Section within a Document
 
-A section represents an organizational subunit within a document. Its definition
-is recursive, since a section can be composed of further `sections`.
+A section represents an organizational subunit within a document. Its 
+definition is recursive, since a section can be composed of further `sections`.
 
 The actual textual content, which is at least a single sentence, but might span
-several paragraphs or more, is stored in `text`. Like a Document, it may
+several paragraphs or more, is stored in `text`. Like a document, it may
 optionally specify a `title`, which semantically corresponds to a section
 header or chapter title.
 
-Sections are flexible, and it's possible that a section specifies a title, but
-relegates the text to subsections. For instance, consider the following simple
-document, excerpted from Wikipedia:
+Sections provide flexibility, and it's possible that a section specifies a 
+title, but relegates the text to subsections. For instance, consider the 
+following simple document excerpt from Wikipedia:
 
 > ## History
 >
@@ -270,14 +107,145 @@ This could be represented as a top-level section titled "History" and no text.
 It would contain two sections, "First inhabitants" and "Spanish rule" that both
 specify text.
 
-The part metadata, held in **metadata_json**, is returned in search query
+The part metadata, held in `metadata_json`, is returned in search query
 results. It can contain, for example, information that links the item to records
 in other systems.
 
-Finally, **custom_dims** allows you to specify additional factors that can be
+Finally, `custom_dims` allows you to specify additional factors that can be
 used at query time to control the ranking of results. The dimensions must be
 defined ahead of time for the corpus, or else they'll be ignored.
 
+## REST Example
+
+### Standard Indexing REST Endpoint
+
+<Config v="names.product"/> exposes a REST endpoint at the following URL
+to index content into a corpus:
+<code>https://<Config v="domains.rest.indexing"/>/v1/index</code>
+
+### Index Request and Response
+
+The request body provides essential information about the document you want to
+index. The Index request requires the following parameters:
+
+* `customerID`
+* `corpusID`
+* `document` object
+
+
+```json
+{
+  "customerId": 123456789,
+  "corpusId": 5,
+  "document": {
+    "documentId": "issbn-9781405053976",
+    "title": "The Hitchhiker's Guide to the Galaxy",
+    "description": "A great book with the answer to life, the universe, and everything",
+    "metadataJson": "{\"author\": \"Douglas Adams\"}",
+    "section": [
+      {
+        "title": "Intro",
+        "text": "Far out in the uncharted backwaters of the unfashionable end of the western spiral arm of the Galaxy lies a small unregarded yellow sun.",
+        "metadataJson": "{\"page\": 1}"
+      },
+      {
+        "title": "The answer",
+        "text": "The Answer to the Great Question ... Of Life, the Universe and Everything ... Is ... Forty-two.",
+        "metadataJson": "{\"speaker\": \"Deep Thought\"}"
+      }
+    ]
+  }
+}
+```
+The response from the server includes a status code and the amount of quota
+consumed:
+
+```json
+{
+  "status": {
+    "code": "OK",
+    "statusDetail": "",
+    "cause": null
+  },
+  "quotaConsumed": {
+    "numChars": "348",
+    "numMetadataChars": "469"
+  }
+}
+```
+## gRPC Example 
+
+You can find the full Standard Indexing gRPC definition at [indexing.proto](https://github.com/vectara/protos/blob/main/indexing.proto).
+
+### Index Document Request and Response
+
+<pre>{`
+message IndexDocumentRequest {
+  int64 customer_id = 1;
+  int64 corpus_id = 2;
+  ${vars['package.protobuf']}.indexing.Document document = 3;
+}
+`}</pre>
+
+:::note
+
+The reply does not block. The information in the request is not necessarily 
+available in the index when the RPC returns. In most cases, it becomes 
+available within a second.
+
+:::
+
+Here is an example response:
+
+```protobuf
+message IndexDocumentResponse {
+  // If ALREADY_EXISTS, it means the document was already indexed, and no new
+  // quota was consumed.
+  Status status = 1;
+
+  // The storage quota needed for the document indexed in the request.
+  // If "status" is ALREADY_EXISTS, it means that the document was already in
+  // the index prior to this request. In such cases, quota is not consumed again
+  // and the value in this field represents the quota consumed when the document
+  // was indexed the first time.
+  StorageQuota quota_consumed = 2;
+}
+```
+
+```protobuf
+message StorageQuota {
+  // The number of chars from the document that consumed the storage quota.
+  int64 num_chars = 1;
+  // The number of chars in the metadata of the document that consumed the
+  // storage quota.
+  int64 num_metadata_chars = 2;
+}
+```
+### Document Format
+
+```protobuf
+message Document {
+  // Client assigned document ID to this document.
+  string document_id = 1;
+  // The title of the document.
+  string title = 2;
+  // An optional description for the document.
+  string description = 3;
+  // Metadata about the document. This should be a json string, and it can be
+  // retrieved at query time.
+  string metadata_json = 4;
+  // A list of custom dimension values that are included in the generated
+  // representation of all sections.
+  repeated CustomDimension custom_dims = 5;
+
+  // The actual content of the document, structured as a repeating list
+  // of sections.
+  repeated Section section = 10;
+}
+
+```
+
+### Section within a Document
 
 ```protobuf
 message Section {

--- a/www/docs/api-reference/indexing-apis/indexing.md
+++ b/www/docs/api-reference/indexing-apis/indexing.md
@@ -6,15 +6,18 @@ sidebar_label: Standard Indexing API Definition
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import {Config} from '@site/docs/definitions.md';
+import CodeBlock from '@theme/CodeBlock';
 import {vars} from '@site/static/variables.json';
+import {Config} from '@site/docs/definitions.md';
 
 The first step in using <Config v="names.product"/> is to index a set of related 
 documents or content into a corpus. Indexing a document enables you to make 
-data available for search and retrieval more efficiently. 
+data available for search and retrieval more efficiently. The Standard 
+Indexing API is recommended for applications where documents already have a 
+clear and consistent structure.
 
-Our standard indexing transforms unstructured or semi-structured data into a 
-format that enables the data to become easily searchable in just a couple of 
+Our Standard Indexing capability transforms this structured data into a 
+format that enables the data to become easily searchable in just a few 
 seconds. We also support a variety of data formats by allowing you to specify 
 multiple document attributes and metadata.
 
@@ -22,7 +25,7 @@ multiple document attributes and metadata.
 
 * Check out our [**interactive API Playground**](/docs/rest-api/index) that lets you experiment 
 with this endpoint to index documents from your browser.
-* We also provide REST Index examples in in [C#](/docs/getting-started-samples/RestIndexData.cs), [Java](/docs/getting-started-samples/RestIndex.java), [NodeJS](/docs/getting-started-samples/index_document.js), [PHP](/docs/getting-started-samples/indexDocument.php), and [Python](/docs/getting-started-samples/rest_index_document.py).
+* We also provide REST Index examples in in [**C#**](/docs/getting-started-samples/RestIndexData.cs), [**Java**](/docs/getting-started-samples/RestIndex.java), [**NodeJS**](/docs/getting-started-samples/index_document.js), [**PHP**](/docs/getting-started-samples/indexDocument.php), and [**Python**](/docs/getting-started-samples/rest_index_document.py).
 
 :::
 
@@ -42,20 +45,21 @@ indicates how much quota would have been consumed.
 
 :::note
 
-The storage quota object returns the number of characters consumed and the number
-of metadata characters consumed. The total quota consumed is simply the sum of
-both values.
+The storage quota object returns the number of characters consumed and the 
+number of metadata characters consumed. The total quota consumed is simply the 
+sum of both values.
 
 :::
 
-## Document Definition
+## Document Object Definition
 
-A `document` object encapsulates the information about the data that you want to 
-index. This object has a `document_id` which must be unique among all the 
-documents in the same corpus. The document may optionally speciify a `title`, 
-`description`, and `metadata`. The core of the document is also structured in 
-`sections` that can include unique identifiers, titles, strings, metadata, and 
-so on.
+A `document` object encapsulates the information about the data that you want 
+to index. A **document** in Vectara is very flexible because it represent a 
+short tweet or book with thousands of pages. This object has a `document_id` 
+which must be unique among all the documents in the same corpus. The document 
+may optionally speciify a `title`, `description`, and `metadata`. The core of 
+the document is also structured in `sections` that can include unique 
+identifiers, titles, strings, metadata, and so on. 
 
 The `custom_dims` field provides default values for the corresponding
 section fields, should they fail to define them explicitly. Most importantly, 
@@ -324,17 +328,4 @@ The server sends an empty reply in response.
 ```protobuf
 message DeleteDocumentResponse {
 }
-```
-
-## Frequently Asked Questions
-
-### Error received from peer...Trying to connect an http1.x server
-
-You are receiving this error message because you are trying to connect via
-an insecure channel. The endpoint only allows secure (TLS) connections.
-
-This is bad:
-
-```python
-grpc.insecure_channel(...)
 ```

--- a/www/docs/api-reference/overview.md
+++ b/www/docs/api-reference/overview.md
@@ -4,12 +4,17 @@ title: Vectara APIs Overview
 sidebar_label: Vectara APIs Overview
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CodeBlock from '@theme/CodeBlock';
+import {vars} from '@site/static/variables.json';
 import {Config} from '@site/docs/definitions.md';
 
 Everything in <Config v="names.product"/> is driven by APIs. This section serves 
 as a roadmap to understanding and using our [gRPC APIs](/docs/api-reference/protobuf-definitions) and 
-[REST APIs](/docs/api-reference/rest). Before getting into more details, we recommend that 
-you have a basic understanding of API concepts.
+[REST APIs](/docs/api-reference/rest) for indexing, searching, and administrative tasks.
+Before getting into more details, we 
+recommend that you have a basic understanding of API concepts.
 
 ## :star2: Ready to Dive In? Check Out Our API Playground! :star2:
 
@@ -46,8 +51,8 @@ provides the message definitions for running queries.
   JWT tokens.
 
 ## Choosing gRPC or REST APIs
-Almost every API has both a [gRPC](https://en.wikipedia.org/wiki/GRPC) and a
-REST(https://en.wikipedia.org/wiki/Representational_state_transfer) endpoint.
+Almost every API has both a [gRPC](https://en.wikipedia.org/wiki/GRPC) and a 
+[REST](https://en.wikipedia.org/wiki/Representational_state_transfer) endpoint.
 The only exception at this time is the [File Upload API](/docs/api-reference/indexing-apis/file-upload/file-upload),
 which is only available via REST.
 

--- a/www/docs/api-reference/select-ideal-indexing-api.md
+++ b/www/docs/api-reference/select-ideal-indexing-api.md
@@ -24,7 +24,7 @@ indexing APIs for these different scenarios:
   
   If you have structured documents that you want Vectara to index and chunk for 
   you, use the standard indexing API. The document typically includes unique 
-  identifiers like title, description, and medtadata. The document is also 
+  identifiers like title, description, and metadata. The document is also 
   structured into sections that each can have a unique ID, title, text, 
   metadata, and so on.
 

--- a/www/docs/api-reference/select-ideal-indexing-api.md
+++ b/www/docs/api-reference/select-ideal-indexing-api.md
@@ -13,12 +13,12 @@ import {Config} from '@site/docs/definitions.md';
 Selecting the ideal Indexing API for your application depends on your needs, 
 such as when you have structured or unstructured documents, or if you need 
 more granular control over the indexing process. Vectara offers the following 
-indexing APIs for these different scenarios.
+indexing APIs for these different scenarios:
 
 * [File Upload API](/docs/api-reference/indexing-apis/file-upload/file-upload)
 
-  If you mainly want to extract text from existing, unstructured documents, use 
-  the File Upload API.
+  If you mainly want to extract text from existing, unstructured documents in 
+  common file types, use the File Upload API.
 
 * [Standard Indexing API](/docs/api-reference/indexing-apis/indexing)
   
@@ -30,8 +30,8 @@ indexing APIs for these different scenarios.
 
 * [Low-Level Indexing API](/docs/api-reference/indexing-apis/core_indexing)
 
-  For the most advanced use cases, if you want full, granular control in what 
-  you want your document chunks to be, use the low-level indexing API. These 
+  For the most advanced use cases, if you want full, granular control to define  
+  your document chunks, use the low-level indexing API. These 
   documents also have a unique ID and metadata, but you also define document
   `parts`:
     - `text` - A part of the document, such as a sentence

--- a/www/docs/api-reference/select-ideal-indexing-api.md
+++ b/www/docs/api-reference/select-ideal-indexing-api.md
@@ -10,23 +10,32 @@ import CodeBlock from '@theme/CodeBlock';
 import {vars} from '@site/static/variables.json';
 import {Config} from '@site/docs/definitions.md';
 
-Selecting the ideal Indexing API depends on your needs, such as when you have
-unstructured files, structured documents, or you need more granular control 
-over the indexing process. Vectara offers the following indexing APIs for 
-these different scenarios.
+Selecting the ideal Indexing API for your application depends on your needs, 
+such as when you have structured or unstructured documents, or if you need 
+more granular control over the indexing process. Vectara offers the following 
+indexing APIs for these different scenarios.
 
 * [File Upload API](/docs/api-reference/indexing-apis/file-upload/file-upload)
 
-  If you mainly want to extract text from existing documents, use the File 
-  Upload API. You can also drag-and-drop documents in the Console UI.
+  If you mainly want to extract text from existing, unstructured documents, use 
+  the File Upload API.
 
 * [Standard Indexing API](/docs/api-reference/indexing-apis/indexing)
   
-  If you have structured documents that you want us to index and chunk for 
-  you, use the standard indexing API. The document can include sections with 
-  titles, text, and metadata. 
+  If you have structured documents that you want Vectara to index and chunk for 
+  you, use the standard indexing API. The document typically includes unique 
+  identifiers like title, description, and medtadata. The document is also 
+  structured into sections that each can have a unique ID, title, text, 
+  metadata, and so on.
 
 * [Low-Level Indexing API](/docs/api-reference/indexing-apis/core_indexing)
 
-  For the most advanced use cases, if you want full, granular control in what you want your document chunks to 
-  be, use the low-level indexing API.
+  For the most advanced use cases, if you want full, granular control in what 
+  you want your document chunks to be, use the low-level indexing API. These 
+  documents also have a unique ID and metadata, but you also define document
+  `parts`:
+    - `text` - A part of the document, such as a sentence
+    - `context` - The more nuanced textual information that defines context, which 
+      may include preceding or following paragraphs.
+    - `metadataJson` - The JSON string that provides more metadata about this part
+      of the document.

--- a/www/docs/api-reference/select-ideal-indexing-api.md
+++ b/www/docs/api-reference/select-ideal-indexing-api.md
@@ -24,7 +24,9 @@ Vectara offers the following indexing APIs for these different scenarios:
   If you want to extract text from existing, unstructured documents in common 
   file types with minimal manual intervention, use the File Upload API.
 
-  We recommend this option when you do not need to define additional 
+  We recommend this option if you haven't written your own extraction logic 
+  already.  
+
   user-supplied metadata beyond what is extracted by the Vectara platform when 
   you upload the `file`. You can still optionally attach metadata by formatting 
   your data as JSON.
@@ -33,23 +35,28 @@ Vectara offers the following indexing APIs for these different scenarios:
 * [Standard Indexing API](/docs/api-reference/indexing-apis/indexing)
   
   If you have structured documents that you want Vectara to index and chunk 
-  for you, use the standard indexing API. The document typically includes 
+  for you, use the standard indexing API. In Vectara, a `document` is very 
+  flexible in what it can represent. It can be as short as a tweet or as long 
+  as the Bible. The document typically includes 
   unique identifiers like title, description, and metadata that you can 
   leverage. The document is also broken down into sections. Each `section` can 
   have a unique `id`, `title`, `text`, and `metadata`.
 
   We recommend this option for applications where documents already have a 
-  clear and consistent structure like news articles or product descriptions.
+  clear and consistent structure like news articles, product descriptions, 
+  rows in database tables or CSV files, or records from an ERP system.
 
 
 * [Low-Level Indexing API](/docs/api-reference/indexing-apis/core_indexing)
 
-  For the most advanced use cases, if you want full, granular control to define
-  your document chunks, use the low-level indexing API. These documents also 
+  For the most advanced use cases, if you want full, granular control to chunk 
+  your document into parts, use the low-level indexing API. These documents also 
   have a unique ID and metadata, but you also define document `parts` that 
   break down into individual `text` blocks, `context`, `metadata`, and custom 
   dimensions. 
 
-  We recommend this option for highly specialized domains which contain complex 
-  information like academic, legal, and scientific.
+  We recommend this option for Machine Learning teams with expertise in neural
+  information retrieval, who want low-level control over how documents are 
+  indexed in our systems. Using the low-level API typically involves a formal 
+  and large coordination with our team.
   

--- a/www/docs/api-reference/select-ideal-indexing-api.md
+++ b/www/docs/api-reference/select-ideal-indexing-api.md
@@ -1,0 +1,32 @@
+---
+id: select-ideal-indexing-api
+title: Select the Ideal Indexing API for Your Needs
+sidebar_label: Select the Ideal Indexing API
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CodeBlock from '@theme/CodeBlock';
+import {vars} from '@site/static/variables.json';
+import {Config} from '@site/docs/definitions.md';
+
+Selecting the ideal Indexing API depends on your needs, such as when you have
+unstructured files, structured documents, or you need more granular control 
+over the indexing process. Vectara offers the following indexing APIs for 
+these different scenarios.
+
+* [File Upload API](/docs/api-reference/indexing-apis/file-upload/file-upload)
+
+  If you mainly want to extract text from existing documents, use the File 
+  Upload API. You can also drag-and-drop documents in the Console UI.
+
+* [Standard Indexing API](/docs/api-reference/indexing-apis/indexing)
+  
+  If you have structured documents that you want us to index and chunk for 
+  you, use the standard indexing API. The document can include sections with 
+  titles, text, and metadata. 
+
+* [Low-Level Indexing API](/docs/api-reference/indexing-apis/core_indexing)
+
+  For the most advanced use cases, if you want full, granular control in what you want your document chunks to 
+  be, use the low-level indexing API.

--- a/www/docs/api-reference/select-ideal-indexing-api.md
+++ b/www/docs/api-reference/select-ideal-indexing-api.md
@@ -10,32 +10,46 @@ import CodeBlock from '@theme/CodeBlock';
 import {vars} from '@site/static/variables.json';
 import {Config} from '@site/docs/definitions.md';
 
-Selecting the ideal Indexing API for your application depends on your needs, 
-such as when you have structured or unstructured documents, or if you need 
-more granular control over the indexing process. Vectara offers the following 
-indexing APIs for these different scenarios:
+Selecting the ideal Indexing API for your application can significantly impact 
+the effectiveness of integrating Vectara’s search functionalities into your 
+application. The best indexing method depends on your needs, such as when you 
+have semi-structured or unstructured documents, or if you want more granular 
+control over the data segmentation and indexing process.
+
+Vectara offers the following indexing APIs for these different scenarios:
+
 
 * [File Upload API](/docs/api-reference/indexing-apis/file-upload/file-upload)
 
-  If you mainly want to extract text from existing, unstructured documents in 
-  common file types, use the File Upload API.
+  If you want to extract text from existing, unstructured documents in common 
+  file types with minimal manual intervention, use the File Upload API.
+
+  We recommend this option when you do not need to define additional 
+  user-supplied metadata beyond what is extracted by the Vectara platform when 
+  you upload the `file`. You can still optionally attach metadata by formatting 
+  your data as JSON.
+
 
 * [Standard Indexing API](/docs/api-reference/indexing-apis/indexing)
   
-  If you have structured documents that you want Vectara to index and chunk for 
-  you, use the standard indexing API. The document typically includes unique 
-  identifiers like title, description, and metadata. The document is also 
-  structured into sections that each can have a unique ID, title, text, 
-  metadata, and so on.
+  If you have structured documents that you want Vectara to index and chunk 
+  for you, use the standard indexing API. The document typically includes 
+  unique identifiers like title, description, and metadata that you can 
+  leverage. The document is also broken down into sections. Each `section` can 
+  have a unique `id`, `title`, `text`, and `metadata`.
+
+  We recommend this option for applications where documents already have a 
+  clear and consistent structure like news articles or product descriptions.
+
 
 * [Low-Level Indexing API](/docs/api-reference/indexing-apis/core_indexing)
 
-  For the most advanced use cases, if you want full, granular control to define  
-  your document chunks, use the low-level indexing API. These 
-  documents also have a unique ID and metadata, but you also define document
-  `parts`:
-    - `text` - A part of the document, such as a sentence
-    - `context` - The more nuanced textual information that defines context, which 
-      may include preceding or following paragraphs.
-    - `metadataJson` - The JSON string that provides more metadata about this part
-      of the document.
+  For the most advanced use cases, if you want full, granular control to define
+  your document chunks, use the low-level indexing API. These documents also 
+  have a unique ID and metadata, but you also define document `parts` that 
+  break down into individual `text` blocks, `context`, `metadata`, and custom 
+  dimensions. 
+
+  We recommend this option for highly specialized domains which contain complex 
+  information like academic, legal, and scientific.
+  

--- a/www/docs/api-reference/select-ideal-indexing-api.md
+++ b/www/docs/api-reference/select-ideal-indexing-api.md
@@ -22,25 +22,29 @@ Vectara offers the following indexing APIs for these different scenarios:
 * [File Upload API](/docs/api-reference/indexing-apis/file-upload/file-upload)
 
   If you want to extract text from existing, unstructured documents in common 
-  file types with minimal manual intervention, use the File Upload API.
-
-  We recommend this option if you haven't written your own extraction logic 
-  already.  
-
-  user-supplied metadata beyond what is extracted by the Vectara platform when 
-  you upload the `file`. You can still optionally attach metadata by formatting 
-  your data as JSON.
-
+  file types with minimal manual intervention, use the File Upload API. This 
+  option enables you to attach additional, user-defined metadata at the 
+  document level. 
+  
+  You can also upload JSON versions of the same Document protocol buffers 
+  passed to the standard indexing API and the low-level indexing API, as long 
+  as the file ends with the `.json` extension. Our platform intelligently 
+  determines which flavor of document proto it's looking at. Note that sending 
+  any other kind of JSON to the indexing endpoint will cause it to error out.
+  
+  We recommend this option if you have not written your own extraction logic 
+  already.
 
 * [Standard Indexing API](/docs/api-reference/indexing-apis/indexing)
   
-  If you have structured documents that you want Vectara to index and chunk 
-  for you, use the standard indexing API. In Vectara, a `document` is very 
-  flexible in what it can represent. It can be as short as a tweet or as long 
-  as the Bible. The document typically includes 
-  unique identifiers like title, description, and metadata that you can 
+  If you have structured documents that you want Vectara to index and segment
+  into chunks for you, use the standard indexing API. In Vectara, a `document` 
+  is very flexible in what it can represent. It can be as short as a tweet or 
+  as long as the 1600 page Bible. The `document` object typically includes 
+  unique identifiers like `title`, `description`, and `metadata` that you can 
   leverage. The document is also broken down into sections. Each `section` can 
-  have a unique `id`, `title`, `text`, and `metadata`.
+  have a unique `id`, `title`, `text`, and `metadata`. Each section can also 
+  contain other sections.
 
   We recommend this option for applications where documents already have a 
   clear and consistent structure like news articles, product descriptions, 
@@ -50,13 +54,16 @@ Vectara offers the following indexing APIs for these different scenarios:
 * [Low-Level Indexing API](/docs/api-reference/indexing-apis/core_indexing)
 
   For the most advanced use cases, if you want full, granular control to chunk 
-  your document into parts, use the low-level indexing API. These documents also 
-  have a unique ID and metadata, but you also define document `parts` that 
-  break down into individual `text` blocks, `context`, `metadata`, and custom 
-  dimensions. 
-
-  We recommend this option for Machine Learning teams with expertise in neural
-  information retrieval, who want low-level control over how documents are 
-  indexed in our systems. Using the low-level API typically involves a formal 
-  and large coordination with our team.
+  your document into `parts`, use the low-level indexing API. These documents 
+  also have a unique ID and metadata, but you also define individual document 
+  `parts` which make up granular sections of the overall document container. 
+  These parts define the actual text to be indexed. Each part is converted 
+  into exactly one vector in the underlying index. Each part can contain 
+  individual `text` blocks, `context`, and` metadata`, as well as custom dimension 
+  values that affect ranking results.
   
+  We recommend this option for Machine Learning teams with expertise in neural
+  information retrieval who want low-level control over how documents are 
+  indexed in our systems. Using the low-level API typically involves 
+  significant coordination between your Machine Learning team and 
+  organizational stakeholders.

--- a/www/docs/learn/select-ideal-indexing-api.md
+++ b/www/docs/learn/select-ideal-indexing-api.md
@@ -19,7 +19,7 @@ control over the data segmentation and indexing process.
 Vectara offers the following indexing APIs for these different scenarios:
 
 
-* [File Upload API](/docs/api-reference/indexing-apis/file-upload/file-upload)
+* [**File Upload API**](/docs/api-reference/indexing-apis/file-upload/file-upload)
 
   If you want to extract text from existing, unstructured documents in common 
   file types with minimal manual intervention, use the File Upload API. This 
@@ -35,7 +35,7 @@ Vectara offers the following indexing APIs for these different scenarios:
   We recommend this option if you have not written your own extraction logic 
   already.
 
-* [Standard Indexing API](/docs/api-reference/indexing-apis/indexing)
+* [**Standard Indexing API**](/docs/api-reference/indexing-apis/indexing)
   
   If you have structured documents that you want Vectara to index and segment
   into chunks for you, use the standard indexing API. In Vectara, a `document` 
@@ -51,7 +51,7 @@ Vectara offers the following indexing APIs for these different scenarios:
   rows in database tables or CSV files, or records from an ERP system.
 
 
-* [Low-Level Indexing API](/docs/api-reference/indexing-apis/core_indexing)
+* [**Low-Level Indexing API**](/docs/api-reference/indexing-apis/core_indexing)
 
   For the most advanced use cases, if you want full, granular control to chunk 
   your document into `parts`, use the low-level indexing API. These documents 

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -199,25 +199,25 @@ module.exports = {
                   },
                 ]
               },
-              {
-                type: 'category',
-                label: 'Document Deletion API',
-                items: [
-                  'api-reference/indexing-apis/deleting-documents',
-                  {
-                    type: 'category',
-                    label: 'REST Examples',
-                    items: [
-                      'getting-started-samples/RestDeleteDocument.cs',
-                      'getting-started-samples/RestDeleteDocument.java',
-                      'getting-started-samples/delete_document.js',
-                      'getting-started-samples/deleteDocument.php',
-                      'getting-started-samples/rest_delete_document.py',
-                    ]
-                  },
-                ]
-              },
             ],
+        },
+        {
+          type: 'category',
+          label: 'Delete Documents API',
+          items: [
+            'api-reference/indexing-apis/deleting-documents',
+            {
+              type: 'category',
+              label: 'REST Examples',
+              items: [
+                'getting-started-samples/RestDeleteDocument.cs',
+                'getting-started-samples/RestDeleteDocument.java',
+                'getting-started-samples/delete_document.js',
+                'getting-started-samples/deleteDocument.php',
+                'getting-started-samples/rest_delete_document.py',
+              ]
+            },
+          ]
         },
         {
             type: 'category',

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -150,34 +150,8 @@ module.exports = {
         'api-reference/api-overview',
         'api-reference/protobuf-definitions',
         'api-reference/rest',
-         {
-            type: 'category',
-            label: 'Authentication Examples',
-            items: [
-              {
-                type: 'category',
-                label: 'OAuth 2.0 Client Credentials Grant Examples',
-                items: [
-                  'getting-started-samples/JWTFetcher.cs',
-                  'getting-started-samples/JwtFetcher.java',
-                  'getting-started-samples/getJwtToken.php',
-                  'getting-started-samples/rest_util.py'
-                ]
-              },
-              {
-                type: 'category',
-                label: 'API Key REST Examples',
-                items: [
-                  'getting-started-samples/RestApiKeyQueries.cs',
-                  'getting-started-samples/RestApiKeyQueries.java',
-                  'getting-started-samples/queryDataApiKey.php',
-                  'getting-started-samples/rest_api_key_queries.py',
-                  'getting-started-samples/app.js',
-                ]
-              }
-           ]
-          },
-        {
+        'api-reference/select-ideal-indexing-api',
+                 {
             type: 'category',
             label: 'Indexing APIs',
             items: [
@@ -349,8 +323,35 @@ module.exports = {
               ]
             },
           ],
-        }
+        },
       ],
+    },
+    {
+      type: 'category',
+      label: 'API Authentication Examples',
+      items: [
+        {
+          type: 'category',
+          label: 'OAuth 2.0 Client Credentials Grant Examples',
+          items: [
+            'getting-started-samples/JWTFetcher.cs',
+            'getting-started-samples/JwtFetcher.java',
+            'getting-started-samples/getJwtToken.php',
+            'getting-started-samples/rest_util.py'
+          ]
+        },
+        {
+          type: 'category',
+          label: 'API Key REST Examples',
+          items: [
+            'getting-started-samples/RestApiKeyQueries.cs',
+            'getting-started-samples/RestApiKeyQueries.java',
+            'getting-started-samples/queryDataApiKey.php',
+            'getting-started-samples/rest_api_key_queries.py',
+            'getting-started-samples/app.js',
+          ]
+        }
+     ]
     },
   ],
   restOAS: [

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -68,6 +68,11 @@ module.exports = {
         },
         {
           type: 'doc',
+          id: 'learn/select-ideal-indexing-api',
+          label: "Select the Ideal Indexing API",
+        },
+        {
+          type: 'doc',
           id: 'learn/enable-keyword-text-matching',
           label: "Enable Exact Keyword Text Matching",
         },
@@ -150,7 +155,6 @@ module.exports = {
         'api-reference/api-overview',
         'api-reference/protobuf-definitions',
         'api-reference/rest',
-        'api-reference/select-ideal-indexing-api',
                  {
             type: 'category',
             label: 'Indexing APIs',


### PR DESCRIPTION
We need to add a topic that guides users about which indexing method to choose and why. Also, updating the topics with the goal to make all API Definition topics more standardized. Will move conceptual information higher in the topic (e.g. defining objects and sections). We need to minimize the amount of code samples in these API topics and snippets for maintenance reasons and instead link more to the API playground and proto files. - WIP