### PR TITLE
Fix reranker URL and update search topic

### DIFF
--- a/www/docs/api-reference/search-apis/reranking.md
+++ b/www/docs/api-reference/search-apis/reranking.md
@@ -15,9 +15,9 @@ that while slower than the rapid retrieval step, offers more accurate results.
 We currently have two rerankers, the English reranker and the Maximal Marginal 
 Relevance (MMR) reranker.
 
-## English Reranker (Scale Only)
+## English Cross-attentional Reranker (Scale Only)
 
-The English reranker is only available to Scale users and you enable it by 
+The English cross-attentional reranker is only available to Scale users and you enable it by 
 specifying `272725717` as the `reranker_id`.
 
 In most scenarios, it makes sense to use the default query `start` value of `0` so 


### PR DESCRIPTION
Fixes #169 

Points the reranker URL to the new topic and also made changes to the Search topic based on new formatting being introduced in PR 208.