### PR TITLE
Update API Reference examples for consistency

### DIFF
--- a/www/docs/api-reference/admin-apis/compute-account-size.md
+++ b/www/docs/api-reference/admin-apis/compute-account-size.md
@@ -23,20 +23,15 @@ Check out our [**interactive API Playground**](/docs/rest-api/compute-account-si
 endpoint to view the account size.
 
 :::
-
-
-## Compute Account Size Request and Response
-
 :::note
 
 The request to compute the account size is an expensive operation.
 
 :::
 
-This request requires the Customer ID parameter. The response includes a `size` 
-object which is the sum of the number of 
-characters and metadata characters.
-
+This request requires the Customer ID parameter and the response includes a
+`size` object which is the sum of the number of characters and metadata 
+characters.
 
 ## REST Example
 
@@ -46,20 +41,8 @@ characters and metadata characters.
 to update the status of a corpus:
 <code>https://<Config v="domains.rest.admin"/>/v1/compute-account-size</code>
 
-### Compute Account Size Example
+The API Playground shows the full [Compute Account Size](/docs/rest-api/compute-account-size) REST definition.
 
-```json
-{
-  "size": [
-    {
-      "numChars": "2638721",
-      "numMetadataChars": "1084267"
-    }
-  ],
-  "status": {
-    "code": "OK",
-    "statusDetail": "",
-    "cause": null
-  }
-}
-  ```
+## gRPC Example
+
+You can find the full Compute Account Size gRPC definition at [admin_account.proto](https://github.com/vectara/protos/blob/main/admin_account.proto).

--- a/www/docs/api-reference/admin-apis/compute-account-size.md
+++ b/www/docs/api-reference/admin-apis/compute-account-size.md
@@ -7,7 +7,7 @@ sidebar_label: Compute Account Size API Definition
 import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
-The Compute Account Size endpoint lets you view how much quota you consumed 
+The Compute Account Size API lets you view how much quota you consumed 
 across the entire account. This capability is useful for administrators who 
 want to track and monitor usage of multiple accounts. For example, you manage 
 multiple tenants and notice that your account usage is higher than expected.
@@ -38,7 +38,7 @@ characters.
 ### Compute Account Size REST Endpoint Address
 
 <Config v="names.product"/> exposes a REST endpoint at the following URL
-to update the status of a corpus:
+to compute the account size:
 <code>https://<Config v="domains.rest.admin"/>/v1/compute-account-size</code>
 
 The API Playground shows the full [Compute Account Size](/docs/rest-api/compute-account-size) REST definition.

--- a/www/docs/api-reference/admin-apis/corpus/compute-corpus-size.md
+++ b/www/docs/api-reference/admin-apis/corpus/compute-corpus-size.md
@@ -24,10 +24,7 @@ endpoint to compute the corpus size.
 
 The request to compute the corpus size provides information about what time 
 the size was calculated and the size of the corpus. This request also requires 
-the following parameters:
-
-* Customer ID
-* Corpus ID
+the `corpus_id` and `customer_id` parameters.
 
 The response includes a `size` object that shows the `epochSecs` and corpus `size`
 values.
@@ -37,21 +34,11 @@ values.
 ### Compute Corpus Size REST Endpoint Address
 
 <Config v="names.product"/> exposes a REST endpoint at the following URL
-to update the status of a corpus:
+to compute the size of a corpus:
 <code>https://<Config v="domains.rest.admin"/>/v1/compute-corpus-size</code>
 
-### Compute Corpus Size Example
+The API Playground shows the full [Compute Corpus Size](/docs/rest-api/compute-corpus-size) REST definition.
 
-```json
-{
-  "size": {
-    "epochSecs": "1704313931",
-    "size": "673229"
-  },
-  "status": {
-    "code": "OK",
-    "statusDetail": "",
-    "cause": null
-  }
-}
-```
+## gRPC Example
+
+You can find the full Compute Corpus Size gRPC definition at [admin.proto](https://github.com/vectara/protos/blob/main/admin.proto).

--- a/www/docs/api-reference/admin-apis/corpus/list-documents.md
+++ b/www/docs/api-reference/admin-apis/corpus/list-documents.md
@@ -7,7 +7,7 @@ sidebar_label: List Documents API Definition
 import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
-The List Documents endpoint lets you view the Document IDs and their metadata 
+The List Documents API lets you view the Document IDs and their metadata 
 in a corpus. This is useful for viewing documents indexed so far and helping 
 you decide to remove documents that are no longer needed. It helps you manage 
 the document lifecycle in your environent.
@@ -19,7 +19,7 @@ capabilities into their applications.
 
 :::tip
 
-Check out our [interactive API Playground](/docs/rest-api/list-documents) that lets you experiment with this 
+Check out our [**interactive API Playground**](/docs/rest-api/list-documents) that lets you experiment with this 
 REST endpoint to manage your documents.
 
 :::
@@ -28,141 +28,22 @@ REST endpoint to manage your documents.
 
 The request to list documents provides detailed information about documents 
 uploaded to the corpus. You can also specify the `numResults`, `pageKey`, and 
-`metadataFilter`. This list documents request also requires the following 
-parameters:
-
-* Customer ID
-* Corpus ID
+`metadataFilter`. This list documents request requires the `corpus_id` and 
+`customer_id` parameters.
 
 The response includes a list of the first 10 documents by default. You can 
 configure up to 1000.
-
 
 ## REST Example
 
 ### List Documents REST Endpoint Address
 
 <Config v="names.product"/> exposes a REST endpoint at the following URL
-to update the status of a corpus:
+to list the documents in a corpus:
 <code>https://<Config v="domains.rest.admin"/>/v1/list-documents</code>
 
-### List Documents Request Example
+The API Playground shows the full [List Documents](/docs/rest-api/list-documents) REST definition.
 
-```json
-{
-  "corpusId": 12,
-  "numResults": 5,
-  "pageKey": "",
-  "metadataFilter": ""
-}
-```
+## gRPC Example
 
-### List Documents Reponse Example
-
-```json
-{
-  "document": [
-    {
-      "id": "NHL2023-24Rulebook_Part1.pdf",
-      "metadata": [
-        {
-          "name": "CreationDate",
-          "value": "1704344165"
-        },
-        {
-          "name": "Producer",
-          "value": "Acrobat 11.0.3"
-        },
-        {
-          "name": "Creator",
-          "value": "Acrobat 11.0.3"
-        },
-        {
-          "name": "ModDate",
-          "value": "1704344166"
-        },
-        {
-          "name": "title",
-          "value": "Section 1 - Playing Area"
-        }
-      ]
-    },
-    {
-      "id": "NHL2023-24Rulebook_Part2.pdf",
-      "metadata": [
-        {
-          "name": "CreationDate",
-          "value": "1704344166"
-        },
-        {
-          "name": "Producer",
-          "value": "Acrobat 11.0.3"
-        },
-        {
-          "name": "Creator",
-          "value": "Acrobat 11.0.3"
-        },
-        {
-          "name": "ModDate",
-          "value": "1704344167"
-        },
-        {
-          "name": "title",
-          "value": "Section 2 - Teams"
-        }
-      ]
-    },
-    {
-      "id": "NHL2023-24Rulebook_Part3.pdf",
-      "metadata": [
-        {
-          "name": "CreationDate",
-          "value": "1704344167"
-        },
-        {
-          "name": "Producer",
-          "value": "Acrobat 11.0.3"
-        },
-        {
-          "name": "Creator",
-          "value": "Acrobat 11.0.3"
-        },
-        {
-          "name": "ModDate",
-          "value": "1704344167"
-        },
-        {
-          "name": "title",
-          "value": "Section 3 - Equipment"
-        }
-      ]
-    },
-    {
-      "id": "NHL2023-24Rulebook_Part4.pdf",
-      "metadata": [
-        {
-          "name": "CreationDate",
-          "value": "1704344168"
-        },
-        {
-          "name": "Producer",
-          "value": "Acrobat 11.0.3"
-        },
-        {
-          "name": "Creator",
-          "value": "Acrobat 11.0.3"
-        },
-        {
-          "name": "ModDate",
-          "value": "1704344168"
-        },
-        {
-          "name": "title",
-          "value": "Section 4 - Types of Penalties"
-        }
-      ]
-    }
-  ],
-  "nextPageKey": ""
-}
-```
+You can find the full List Documents gRPC definition at [list_documents.proto](https://github.com/vectara/protos/blob/main/list_documents.proto).

--- a/www/docs/api-reference/admin-apis/corpus/list-documents.md
+++ b/www/docs/api-reference/admin-apis/corpus/list-documents.md
@@ -10,7 +10,7 @@ import {vars} from '@site/static/variables.json';
 The List Documents API lets you view the Document IDs and their metadata 
 in a corpus. This is useful for viewing documents indexed so far and helping 
 you decide to remove documents that are no longer needed. It helps you manage 
-the document lifecycle in your environent.
+the document lifecycle in your enviroment.
 
 This information enables you to catalog and inventory large amounts of data 
 while also extracting lists of documents for further analysis. For example, 

--- a/www/docs/api-reference/admin-apis/corpus/read-corpus.md
+++ b/www/docs/api-reference/admin-apis/corpus/read-corpus.md
@@ -7,7 +7,7 @@ sidebar_label: Read Corpus API Definition
 import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
-The Read Corpus endpoint lets you view detailed information about corpora 
+The Read Corpus API lets you view detailed information about corpora 
 within your account. It enables you to view different aspects about the corpus 
 including basic information like the ID, name, whether it is enabled or 
 disabled, and other metadata. You can also view the corpus size, associated 
@@ -38,10 +38,8 @@ REST endpoint to manage your corpus details.
 The request to read corpus data provides detailed information about the corpus.
 You specify either `true` or `false` whether you want to view basic 
 information, corpus size, associated API keys, custom dimensions, and filter 
-attributes. This read corpus request also requires the following parameters:
-
-* Customer ID
-* Corpus ID
+attributes. This read corpus request also requires `corpus_id` and `customer_id` 
+parameters.
 
 The response includes detailed information about the corpus depending on what 
 you specified in the request. For example, you wanted to know the associated 
@@ -52,115 +50,11 @@ API keys with a specific corpus.
 ### Read Corpus REST Endpoint Address
 
 <Config v="names.product"/> exposes a REST endpoint at the following URL
-to ingest content into a corpus:
+to read a corpus:
 <code>https://<Config v="domains.rest.admin"/>/v1/read-corpus</code>
 
-### Read Corpus Request Example
+The API Playground shows the full [Read Corpus](/docs/rest-api/read-corpus) REST definition.
 
-```json
-{
-  "corpusId": [
-    8
-  ],
-  "readBasicInfo": true,
-  "readSize": true,
-  "readApiKeys": true,
-  "readCustomDimensions": true,
-  "readFilterAttributes": true
-}
-```
+## gRPC Example
 
-### Read Corpus Response Example
-
-The following shows an example response:
-
-```json
-{
-  "corpora": [
-    {
-      "corpus": {
-        "id": 5,
-        "name": "Employee handbooks",
-        "description": "The employee handbook for 2024",
-        "enabled": true,
-        "swapQenc": true,
-        "swapIenc": true,
-        "textless": true,
-        "encrypted": true,
-        "encoderId": "1",
-        "metadataMaxBytes": 0,
-        "customDimensions": [
-          {}
-        ],
-        "filterAttributes": [
-          {
-            "name": "custom1",
-            "description": "Custom filter",
-            "indexed": true,
-            "type": "FILTER_ATTRIBUTE_TYPE__UNDEFINED",
-            "level": "FILTER_ATTRIBUTE_LEVEL__UNDEFINED"
-          }
-        ]
-      },
-      "corpusStatus": {
-        "code": "OK",
-        "statusDetail": "",
-      },
-      "size": {
-        "epochSecs": "1704067200",
-        "size": "4026"
-      },
-      "sizeStatus": {
-        "code": "OK",
-        "statusDetail": "",
-      },
-      "apiKey": [
-        {
-          "id": "1234",
-          "description": "API Key for the employee handbook corpus",
-          "keyType": "API_KEY_TYPE__SERVING_INDEXING",
-          "enabled": true,
-          "tsStart": "5678",
-          "tsEnd": "",
-          "status": "ENABLED"
-        }
-      ],
-      "apiKeyStatus": {
-        "code": "OK",
-        "statusDetail": "string",
-      },
-      "customDimension": [
-        {}
-      ],
-      "customDimensionStatus": {
-        "code": "OK",
-        "statusDetail": "string",
-      },
-      "filterAttribute": [
-        {
-          "name": "doc.id",
-          "description": "",
-          "indexed": true,
-          "type": "FILTER_ATTRIBUTE_TYPE__TEXT",
-          "level": "FILTER_ATTRIBUTE_LEVEL__DOCUMENT"
-        },
-        {
-          "name": "is_title",
-          "description": "True if the text is a title.",
-          "indexed": true,
-          "type": "FILTER_ATTRIBUTE_TYPE__BOOLEAN",
-          "level": "FILTER_ATTRIBUTE_LEVEL__DOCUMENT_PART"
-        },
-        {
-          "name": "lang",
-          "description": "Detected language, as an ISO 639-3 code.",
-          "indexed": true,
-          "type": "FILTER_ATTRIBUTE_TYPE__TEXT",
-          "level": "FILTER_ATTRIBUTE_LEVEL__DOCUMENT_PART"
-        }
-      ],
-      "filterAttributeStatus": null
-    }
-  ]
-}
-```
+You can find the full Read Corpus gRPC definition at [admin.proto](https://github.com/vectara/protos/blob/main/admin.proto).

--- a/www/docs/api-reference/admin-apis/corpus/update-corpus-enablement.md
+++ b/www/docs/api-reference/admin-apis/corpus/update-corpus-enablement.md
@@ -8,7 +8,7 @@ import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
 
-The Update Corpus Enablement endpoint lets you enable or disable a corpus. 
+The Update Corpus Enablement API lets you enable or disable a corpus. 
 This is useful to manage the availability of data within the system, such as 
 when you need to take the corpus offline without having to delete the corpus. 
 
@@ -26,10 +26,8 @@ REST endpoint to enable or disable corpora.
 
 ## Update Corpus Enablement Request and Response
 
-The request to enable or disable a corpus requires the following parameters:
-
-* Customer ID
-* Corpus ID
+The request to enable or disable a corpus requires `corpus_id` and setting `enable` 
+to `true` or `false`.
 
 ## REST Example
 
@@ -39,25 +37,8 @@ The request to enable or disable a corpus requires the following parameters:
 to update the status of a corpus:
 <code>https://<Config v="domains.rest.admin"/>/v1/update-corpus-enablement</code>
 
-### Update Corpus Enablement Request Example
+The API Playground shows the full [Update Corpus Enablement](/docs/rest-api/update-corpus-enablement) REST definition.
 
-In this example, you enable a corpus with the ID of `15`.
+## gRPC Example
 
-```json
-{
-  "corpusId": "15",
-  "enable": true
-}
-```
-
-### Update Corpus Enablement Response Example
-
-```json
-{
-  "status": {
-    "code": "OK",
-    "statusDetail": "",
-    "cause": null
-  }
-}
-```
+You can find the full Update Corpus Enablement gRPC definition at [admin.proto](https://github.com/vectara/protos/blob/main/admin.proto).

--- a/www/docs/api-reference/admin-apis/corpus/update-corpus-enablement.md
+++ b/www/docs/api-reference/admin-apis/corpus/update-corpus-enablement.md
@@ -7,12 +7,11 @@ sidebar_label: Update Corpus Enablement API Definition
 import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
-
 The Update Corpus Enablement API lets you enable or disable a corpus. 
 This is useful to manage the availability of data within the system, such as 
 when you need to take the corpus offline without having to delete the corpus. 
 
-This capability can help you utilize automated scripts to programatically 
+This capability can help you utilize automated scripts to programmatically 
 control the availability of corpora based on certain conditions. For example, 
 quickly disable a corpus for maintenance updates or in response to security 
 incidents. 

--- a/www/docs/api-reference/admin-apis/create-corpus.md
+++ b/www/docs/api-reference/admin-apis/create-corpus.md
@@ -7,64 +7,21 @@ sidebar_label: Create Corpus API Definition
 import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
-The Create Corpus endpoint lets you create a corpus that contains specific 
+The Create Corpus API lets you create a corpus that contains specific 
 properties and attributes.
 
-## Create Corpus REST Endpoint
 
-<Config v="names.product"/> exposes a REST endpoint at the following URL
-to ingest content into a corpus:
-<code>https://<Config v="domains.rest.admin"/>/v1/create-corpus</code>
+:::tip
 
-### Create Corpus Request Headers
+Check out our [**API Playground**](/docs/rest-api/create-corpus) that lets you experiment with this REST endpoint 
+to create corpora.
 
-To interact with the Create Corpus service via REST calls, you need the following 
-headers:
+:::
 
-* `customer_id` is the customer ID to use for the request.
-* JWT token as your `Bearer Token`
-* (Optional) `grpc-timeout` lets you specify how long to wait for the calls 
-  that have the potential to take longer to process. We recommend 
-  `-H "grpc-timeout: 30S"`
+## Corpus Object
 
-### Create Corpus Request Body
-
-Only the `name` and `description` fields are mandatory when creating a corpus.
-
-```json
-{
-  "corpus": {
-    "id": 0,
-    "name": "string",
-    "description": "string",
-    "dtProvision": "string",
-    "enabled": true,
-    "swapQenc": true,
-    "swapIenc": true,
-    "textless": true,
-    "encrypted": true,
-    "encoderId": "string",
-    "metadataMaxBytes": 0,
-    "customDimensions": [
-      {
-        "name": "string",
-        "description": "string",
-        "servingDefault": 0,
-        "indexingDefault": 0
-      }
-    ],
-    "filterAttributes": [
-      {
-        "name": "string",
-        "description": "string",
-        "indexed": true,
-        "type": "FILTER_ATTRIBUTE_TYPE__UNDEFINED",
-        "level": "FILTER_ATTRIBUTE_LEVEL__UNDEFINED"
-      }
-    ]
-  }
-}
-```
+When you create a `corpus` object, only the `name` and `description` fields are 
+mandatory.
 
 The response message returns a unique id, `corpus_id`, by which the corpus can
 be subsequently referenced. Note that the name needn't be unique within an
@@ -74,61 +31,12 @@ In order to reference metadata in [filter expressions](/docs/learn/metadata-sear
 referenceable attributes must be declared at creation time in the **filter
 attributes**. This list cannot be changed once the corpus is created.
 
-For information on **custom dimensions** please see
+For information on **custom dimensions**, a Scale-only feature, please see
 [Custom Dimensions](/docs/learn/semantic-search/add-custom-dimensions).
-Like filter attributes, custom dimensions cannot be changed after the corpus is created.
+Like filter attributes, custom dimensions cannot be changed after the corpus 
+is created.
 
-```protobuf
-message CreateCorpusRequest {
-  Corpus corpus = 1;
-}
-
-message CreateCorpusResponse {
-  // The corpus id that was created.
-  uint32 corpus_id = 1;
-  Status status = 2;
-}
-
-message Corpus {
-  // The corpus id.
-  uint32 id = 1;
-  // The name of the corpus.
-  string name = 2;
-  // A description for the corpus.
-  string description = 3;
-  // The time at which the corpus was provisioned.
-  int64 dt_provision = 4;
-  // Whether the corpus is enabled for use or not.
-  bool enabled = 5;
-
-  
-  bool swap_qenc = 6;
-  // The default query encoder is designed for normal question-answering types
-  // of queries when the text contains the answer.  Swapping the index encoder
-  // is generally rare, but can be used to help directly match questions to
-  // questions.  This can be useful if you have a FAQ dataset and you want to
-  // directly match the user question to the question in the FAQ.
-  bool swap_ienc = 7;
-  // When a corpus is "textless", Vectara does not store the original text.
-  // Instead, Vectara converts the text to vectors and only retains metadata.
-  bool textless = 8;
-  // Encryption is on by default and cannot be turned off.
-  bool encrypted = 9;
-
-  // This is an advanced setting for changing the underlying model type.  The
-  // default value is "1", which is Vectara's high-performing global model.
-  // Underlying models may be swapped for some paying customers by contacting
-  // our support team.
-  uint64 encoder_id = 10;
-  // An optional maximum size of the metadata that each document can contain.
-  uint32 metadata_max_bytes = 11;
-
-  repeated Dimension custom_dimensions = 13;
-  repeated FilterAttribute filter_attributes = 14;
-}
-```
-
-#### Filter Attribute
+## Filter Attribute
 
 A filter attribute must specify a **name**, and a **level** which indicates
 whether it exists in the document or part level metadata. At indexing time,
@@ -149,32 +57,21 @@ values.
 [1]: https://en.wikipedia.org/wiki/Double-precision_floating-point_format
 [2]: https://en.wikipedia.org/wiki/UTF-8
 
+## REST Example
 
-```
-message FilterAttribute {
-  // Name of the field, as seen in metadata.
-  string name = 5;
-  // An optional description.
-  string description = 10;
-  // Whether the field is indexed for maximum query speed.
-  bool indexed = 15;
-  // The data type of the attribute.
-  FilterAttributeType type = 20;
-  // Whether the attribute lives at the document or part level.
-  FilterAttributeLevel level = 25;
-}
+### Create Corpus REST Endpoint
 
-enum FilterAttributeType {
-  FILTER_ATTRIBUTE_TYPE__UNDEFINED = 0;
-  FILTER_ATTRIBUTE_TYPE__INTEGER = 5;
-  FILTER_ATTRIBUTE_TYPE__REAL = 15;
-  FILTER_ATTRIBUTE_TYPE__TEXT = 25;
-  FILTER_ATTRIBUTE_TYPE__BOOLEAN = 35;
-}
+<Config v="names.product"/> exposes a REST endpoint at the following URL
+to ingest content into a corpus:
+<code>https://<Config v="domains.rest.admin"/>/v1/create-corpus</code>
 
-enum FilterAttributeLevel {
-  FILTER_ATTRIBUTE_LEVEL__UNDEFINED = 0;
-  FILTER_ATTRIBUTE_LEVEL__DOCUMENT = 5;         // Document-level attribute
-  FILTER_ATTRIBUTE_LEVEL__DOCUMENT_PART = 10;   // Part-level attribute
-}
-```
+The API Playground shows the full [Create Corpus](/docs/rest-api/create-corpus) REST definition.
+
+## gRPC Example
+
+You can find the full Create Corpus gRPC definition at [admin.proto](https://github.com/vectara/protos/blob/main/admin.proto).
+
+The `CreateCorpusRequest` message contains a Corpus message with the name, 
+description, and other customization options. The `CreateCorpusResponse` 
+provides the response with the new Corpus ID and status.
+

--- a/www/docs/api-reference/admin-apis/delete-corpus.md
+++ b/www/docs/api-reference/admin-apis/delete-corpus.md
@@ -7,25 +7,34 @@ sidebar_label: API Definition
 import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
+The Delete Corpus API lets you delete a corpus. To delete a corpus, specify 
+the `customer_id` and `corpus_id`. Upon successful completion, space quota 
+consumed by the corpus will be freed, and the corpus will no longer be useable 
+for future indexing or querying. 
+
+:::note
+
+The corpus_id assigned to the corpus will not be reused.
+
+:::
+
+:::tip
+
+Check out our [**API Playground**](/docs/rest-api/delete-corpus) that lets you experiment with this REST endpoint 
+to delete corpora.
+
+:::
+
+## REST Example
+
+### Delete Corpus REST Endpoint
+
 <Config v="names.product"/> exposes a REST endpoint at the following URL
 to ingest content into a corpus:
 <code>https://<Config v="domains.rest.admin"/>/v1/delete-corpus</code>
-This page describes the details of interacting with this endpoint.
 
-To delete a corpus, specify the `customer_id` and `corpus_id`. Upon
-successful completion, space quota consumed by the corpus will be freed,
-and the corpus will no longer be useable for future indexing or querying.
-Note that the corpus_id assigned to the corpus will not be reused.
+The API Playground shows the full [Delete Corpus](/docs/rest-api/delete-corpus) REST definition.
 
-```protobuf
-message DeleteCorpusRequest {
-  // The customer id that contains the corpus to be deleted.
-  uint32 customer_id = 1;
-  // The corpus id to be deleted.
-  uint32 corpus_id = 2;
-}
+## gRPC Example
 
-message DeleteCorpusResponse {
-  Status status = 1;
-}
-```
+You can find the full Delete Corpus gRPC definition at [admin.proto](https://github.com/vectara/protos/blob/main/admin.proto).

--- a/www/docs/api-reference/admin-apis/manage-users/list-users.md
+++ b/www/docs/api-reference/admin-apis/manage-users/list-users.md
@@ -12,45 +12,33 @@ import {vars} from '@site/static/variables.json';
 The List Users endpoint lets you list all users on your team and also their
 corpus access and customer-level authorizations.
 
-Other activities
-such as adding, deleting, enabling, disabling, resetting passwords, and 
-editing user roles are performed by the [Manage Users](/docs/api-reference/admin-apis/manage-users/manage-user) endpoint.
+Other activities such as adding, deleting, enabling, disabling, resetting 
+passwords, and editing user roles are performed by the [Manage Users](/docs/api-reference/admin-apis/manage-users/manage-user) endpoint.
 
-## List Users Endpoint Address
-
-<Config v="names.product"/> exposes a REST endpoint at the following URL
-to index content into a corpus:
-<code>https://<Config v="domains.rest.indexing"/>/v1/list-users</code>
-
-## Manage Users from the API Playground
+:::tip
 
 Check out our [interactive API Playground](/docs/rest-api/list-users) that lets 
 you experiment with this REST endpoint to manage users for your Vectara
 account.
 
+:::
 
-### Request Headers
+## listUsersType
 
-To interact with the List Users service via REST calls, you need the following headers:
+The `listUsersType` specifies the type of user as none, all, or only to list 
+users with a customer account level. You can also pass a `page_key` to 
+retrieve a specific page of results. Leave empty to retrieve first page. 
 
-* `customer_id` is the Customer ID to use for the request
-* An API Key or JWT Token as your authentication method
+## REST Example
 
+### List Users Endpoint Address
 
-### Request Body
+<Config v="names.product"/> exposes a REST endpoint at the following URL
+to index content into a corpus:
+<code>https://<Config v="domains.rest.indexing"/>/v1/list-users</code>
 
-The List Users request body has the following parameters:
-* `list_users_type` - Specifies the type of users as none, all, or only to list users
-  with acustomer account level.
-* `page_key`
-* `num_results`
+The API Playground shows the full [List Users](/docs/rest-api/compute-account-size) REST definition.
 
+## gRPC Example
 
-```json
-{
-    "list_users_type": ["LIST_USERS_TYPE__NONE", "LIST_USERS_TYPE__CUSTOMER", 
-    "LIST_USERS_TYPE__ALL"],
-    "page_key": "encrypted_key",
-    "num_results": "5",
-}
-```
+You can find the full List Users gRPC definition at [admin_user.proto](https://github.com/vectara/protos/blob/main/admin_user.proto).

--- a/www/docs/api-reference/admin-apis/manage-users/list-users.md
+++ b/www/docs/api-reference/admin-apis/manage-users/list-users.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
-The List Users endpoint lets you list all users on your team and also their
+The List Users API lets you list all users on your team and also their
 corpus access and customer-level authorizations.
 
 Other activities such as adding, deleting, enabling, disabling, resetting 
@@ -34,7 +34,7 @@ retrieve a specific page of results. Leave empty to retrieve first page.
 ### List Users Endpoint Address
 
 <Config v="names.product"/> exposes a REST endpoint at the following URL
-to index content into a corpus:
+to list users:
 <code>https://<Config v="domains.rest.indexing"/>/v1/list-users</code>
 
 The API Playground shows the full [List Users](/docs/rest-api/compute-account-size) REST definition.

--- a/www/docs/api-reference/admin-apis/manage-users/manage-user.md
+++ b/www/docs/api-reference/admin-apis/manage-users/manage-user.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
-The Manage User endpoint lets you perform different user and team management 
+The Manage User API lets you perform different user and team management 
 activities such as adding, deleting, enabling, disabling, and editing user 
 roles. This capability is useful in scenarios that require dynamic team 
 management.
@@ -37,7 +37,7 @@ The `userActionType` object contains the `user` object, which specifies the
 ### Manage User Endpoint Address
 
 <Config v="names.product"/> exposes a REST endpoint at the following URL
-to index content into a corpus:
+to manage users:
 <code>https://<Config v="domains.rest.indexing"/>/v1/manage-user</code>
 
 The API Playground shows the full [Manag User](/docs/rest-api/manage-user) REST definition.

--- a/www/docs/api-reference/admin-apis/manage-users/manage-user.md
+++ b/www/docs/api-reference/admin-apis/manage-users/manage-user.md
@@ -19,82 +19,29 @@ endpoint lets you streamline the onboarding process by programatically
 adding new users, assigning appropriate roles, and setting up access 
 permissions.
 
-## Manage User Endpoint Address
-
-<Config v="names.product"/> exposes a REST endpoint at the following URL
-to index content into a corpus:
-<code>https://<Config v="domains.rest.indexing"/>/v1/manage-user</code>
-
-## Manage Users from the API Playground
+:::tip
 
 Check out our [interactive API Playground](/docs/rest-api/manage-user) that lets 
 you experiment with this REST endpoint to manage users for your Vectara
 account.
 
+:::
 
-### Request Headers
+## userActionType Object
 
-To interact with the Manage User service via REST calls, you need the following headers:
-* `customer_id` is the Customer ID to use for the request
-* An API Key or JWT Token as your authentication method
+The `userActionType` object contains the `user` object, which specifies the 
+`id`, `handle`, `userStatus`, `role`, and other information about the user.
 
+## REST Example
 
-### Request Body
+### Manage User Endpoint Address
 
-The Manage User request body requires the following parameters:
+<Config v="names.product"/> exposes a REST endpoint at the following URL
+to index content into a corpus:
+<code>https://<Config v="domains.rest.indexing"/>/v1/manage-user</code>
 
-* `handle` - Specifies the ID of the user.
-* `type` - Specifies the type of user:
-   -  `USER_TYPE__NONE` - A default user type, typically used as a placeholder.
-   -  `USER_TYPE__USER` - A standard user type for users who will interact with the Vectara
-      platform.
-   -  `USER_TYPE__FEDERATED_USER` - A user authenticated by an external identity provider 
-      such as Google.
-   -  `USER_TYPE__APP_CLIENT` - An application client and not individual users. These 
-      application-level clients interact with the system.
-* `email`
-* `userActionType` - Specifies the type of action for the user:
-  -  `USER_ACTION_TYPE__ADD` 
-  - `USER_ACTION_TYPE__DELETE`
-  - `USER_ACTION_TYPE__DISABLE`
-  - `USER_ACTION_TYPE__ENABLE`
-  - `USER_ACTION_TYPE__RESET_PASSWORD`
-  - `USER_ACTION_TYPE__EDIT_ROLE`
+The API Playground shows the full [Manag User](/docs/rest-api/manage-user) REST definition.
 
-```json
-{
- "userAction": [
-   {
-     "user": {
-       "handle": "firstlast",
-       "type": "USER_TYPE__USER",
-       "email": "firstlast@gmail.com"
-     },
-     "userActionType": ["USER_ACTION_TYPE__ADD", "USER_ACTION_TYPE__DELETE", 
-     "USER_ACTION_TYPE__DISABLE", "USER_ACTION_TYPE__ENABLE", 
-     "USER_ACTION_TYPE__RESET_PASSWORD", "USER_ACTION_TYPE__EDIT_ROLE"]
-    }
-   }
- ]
-}
-```
+## gRPC Example
 
-## Example: Onboard a New User to your Account
-
-In this example, you want to create a new user for your account.
-
-```json
-{
- "userAction": [
-   {
-     "user": {
-       "handle": "johndoe",
-       "type": "USER_TYPE__USER",
-       "email": "johndoe@email.com"
-     },
-     "userActionType": "USER_ACTION_TYPE__ADD"
-   }
- ]
-}
-
-```
+You can find the full Manage User gRPC definition at [admin_user.proto](https://github.com/vectara/protos/blob/main/admin_user.proto).

--- a/www/docs/api-reference/admin-apis/manage-users/manage-user.md
+++ b/www/docs/api-reference/admin-apis/manage-users/manage-user.md
@@ -40,7 +40,7 @@ The `userActionType` object contains the `user` object, which specifies the
 to manage users:
 <code>https://<Config v="domains.rest.indexing"/>/v1/manage-user</code>
 
-The API Playground shows the full [Manag User](/docs/rest-api/manage-user) REST definition.
+The API Playground shows the full [Manage User](/docs/rest-api/manage-user) REST definition.
 
 ## gRPC Example
 

--- a/www/docs/api-reference/admin-apis/reset-corpus.md
+++ b/www/docs/api-reference/admin-apis/reset-corpus.md
@@ -7,22 +7,29 @@ sidebar_label: API Definition
 import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
-<Config v="names.product"/> exposes a REST endpoint at the following URL
-to reset a corpus:
-<code>https://<Config v="domains.rest.admin"/>/v1/reset-corpus</code>
-This page describes the details of interacting with this endpoint.
+The Reset Corpus API lets you reset a corpus. This operation deletes the 
+contents of a corpus, but it does not delete the corpus itself.
 
 To reset a corpus, specify the `customer_id` and `corpus_id`. Upon 
 successful completion, space quota consumed by the corpus will be freed.
 
-```protobuf
-message ResetCorpusRequest {
-  uint32 customer_id = 1;
-  // The corpus id to reset.
-  uint32 corpus_id = 2;
-}
+:::tip
 
-message ResetCorpusResponse {
-  Status status = 1;
-}
-```
+Check out our [**API Playground**](/docs/rest-api/reset-corpus) that lets you experiment with this REST endpoint 
+to reset corpora.
+
+:::
+
+## REST Example
+
+### Reset Corpus REST Endpoint
+
+<Config v="names.product"/> exposes a REST endpoint at the following URL
+to reset a corpus:
+<code>https://<Config v="domains.rest.admin"/>/v1/reset-corpus</code>
+
+The API Playground shows the full [Delete Corpus](/docs/rest-api/delete-corpus) REST definition.
+
+## gRPC Example
+
+You can find the full Reset Corpus gRPC definition at [admin.proto](https://github.com/vectara/protos/blob/main/admin.proto).

--- a/www/docs/api-reference/api-keys/create-api-key.md
+++ b/www/docs/api-reference/api-keys/create-api-key.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
-The Create API Key endpoint lets you create new API keys, which you can 
+The Create API Key API lets you create new API keys, which you can 
 bind to one or multiple corpora. You can also decide whether to designate each 
 key for specific access like only querying (read-only) or both querying and 
 indexing (read-write).
@@ -18,43 +18,25 @@ This capability is useful in scenarios where you have applications that
 require different levels of access to corpora data. For example, you might 
 create a read-only API key for an application that only needs to query data.
 
-## Create API Key Endpoint Address
+The `apiKeyData` object includes a `description`, `apiKeyType`, and `corpusId`.
 
-<Config v="names.product"/> exposes a REST endpoint at the following URL
-to index content into a corpus:
-<code>https://<Config v="domains.rest.indexing"/>/v1/create-api-key</code>
+:::tip
 
-## Create an API Key from the API Playground
-
-Check out our [interactive API Playground](/docs/rest-api/create-api-key) that lets 
+Check out our [**interactive API Playground**](/docs/rest-api/create-api-key) that lets 
 you experiment with this REST endpoint to create API keys for your account.
 
-### Request Headers
+:::
 
-To interact with the Index service via REST calls, you need the following 
-headers:
+## REST API Example
 
-* `customer_id` is the customer ID to use for the request.
-* An JWT token as your authentication method
+### Create API Key Endpoint Address
 
-### Request Body
+<Config v="names.product"/> exposes a REST endpoint at the following URL
+to create API keys:
+<code>https://<Config v="domains.rest.indexing"/>/v1/create-api-key</code>
 
-The Create API Key request body requires the following parameters:
-* `description` - Provides details about the API key
-* `apiKeyType` - Indicates the type of API key including `API_KEY_TYPE__UNDEFINED` 
-  (default), `API_KEY_TYPE__SERVING`, or `API_KEY_TYPE__SERVING_INDEXING`.
-* `corpusId` - Specifies the corpus IDs where you want to bind the API key.
+The API Playground shows the full [Create API Key](/docs/rest-api/create-api-key) REST definition.
 
-```json
-{
-  "apiKeyData": [
-    {
-      "description": "Description of the ApiKey.",
-      "apiKeyType": "API_KEY_TYPE__UNDEFINED",
-      "corpusId": [
-        12
-      ]
-    }
-  ]
-}
-```
+## gRPC Example
+
+You can find the full Create API Key gRPC definition at [admin_apikey.proto](https://github.com/vectara/protos/blob/main/admin_apikey.proto).

--- a/www/docs/api-reference/api-keys/create-api-key.md
+++ b/www/docs/api-reference/api-keys/create-api-key.md
@@ -11,14 +11,22 @@ import {vars} from '@site/static/variables.json';
 
 The Create API Key API lets you create new API keys, which you can 
 bind to one or multiple corpora. You can also decide whether to designate each 
-key for specific access like only querying (read-only) or both querying and 
-indexing (read-write).
+key for specific access like personal API keys, only querying (read-only) or 
+both querying and indexing (read-write).
 
 This capability is useful in scenarios where you have applications that 
 require different levels of access to corpora data. For example, you might 
 create a read-only API key for an application that only needs to query data.
 
-The `apiKeyData` object includes a `description`, `apiKeyType`, and `corpusId`.
+:::note
+
+For more information about the different types of API keys, see 
+[**API Key Management**](/docs/learn/authentication/api-key-management).
+
+:::
+
+The `apiKeyData` object includes a `description`, `apiKeyType` (query-only, 
+indexing and querying, or personal access key), and `corpusId`.
 
 :::tip
 

--- a/www/docs/api-reference/api-keys/delete-api-key.md
+++ b/www/docs/api-reference/api-keys/delete-api-key.md
@@ -9,40 +9,31 @@ import TabItem from '@theme/TabItem';
 import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
-The Delete API Key endpoint lets you delete one or more existing API keys. 
+The Delete API Key API lets you delete one or more existing API keys. 
 This capability is useful for managing the lifecycle and security of API keys 
 such as when they are no longer needed or when a key is compromised.
 
-## Delete API Key Endpoint Address
+## keyID String
 
-<Config v="names.product"/> exposes a REST endpoint at the following URL
-to index content into a corpus:
-<code>https://<Config v="domains.rest.indexing"/>/v1/delete-api-key</code>
+The `keyID` specifies the API key or list of keys that you want to delete.
 
-## Delete an API Key from the API Playground
+:::tip
 
-Check out our [interactive API Playground](/docs/rest-api/delete-api-key) that lets 
+Check out our [**interactive API Playground**](/docs/rest-api/delete-api-key) that lets 
 you experiment with this REST endpoint to delete API keys from an account.
 
-### Request Headers
+:::
 
-To interact with the Index service via REST calls, you need the following 
-headers:
+## REST Example
 
-* `customer_id` is the customer ID to use for the request.
-* An JWT token as your authentication method
+### Delete API Key Endpoint Address
 
-### Request Body
+<Config v="names.product"/> exposes a REST endpoint at the following URL
+to delete API keys:
+<code>https://<Config v="domains.rest.indexing"/>/v1/delete-api-key</code>
 
+The API Playground shows the full [Delete API Key](/docs/rest-api/delete-api-key) REST definition.
 
-The Delete API Key request body requires the `keyID` of the API key you 
-want to delete.
+## gRPC Example
 
-
-```json
-{
-  "keyId": [
-    "6o59jjft9o02jtga72pjfv3qpn"
-  ]
-}
-```
+You can find the full Delete API Key gRPC definition at [admin_apikey.proto](https://github.com/vectara/protos/blob/main/admin_apikey.proto).

--- a/www/docs/api-reference/api-keys/enable-api-key.md
+++ b/www/docs/api-reference/api-keys/enable-api-key.md
@@ -9,46 +9,34 @@ import TabItem from '@theme/TabItem';
 import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
-The Enable API Key endpoint lets you enable or disable specific API keys. You 
+The Enable API Key API lets you enable or disable specific API keys. You 
 can use this endpoint to temporarily disable access without deleting the key.
 
 This capability is useful for scenarios like maintenance windows. or when your 
 team no longer requires access to a specific corpus.
 
-## Enable API Key REST Endpoint
+## keyEnablement Object
 
-<Config v="names.product"/> exposes a REST endpoint at the following URL
-to index content into a corpus:
-<code>https://<Config v="domains.rest.indexing"/>/v1/enable-api-key</code>
+The `keyEnablement` object contains pairs of a `keyID` with the `enable` 
+status as enable (`true`) or disable (`false`) the API key.
 
-## Enable an API Key from the API Playground
+:::tip
 
-Check out our [interactive API Playground](/docs/rest-api/enable-api-key) that lets 
+Check out our [**interactive API Playground**](/docs/rest-api/enable-api-key) that lets 
 you experiment with this REST endpoint to enable and disable API keys.
 
-### Request Headers
+:::
 
-To interact with the Index service via REST calls, you need the following 
-headers:
+## REST Example
 
-* `customer_id` is the customer ID to use for the request.
-* An JWT token as your authentication method
+### Enable API Key REST Endpoint Address
 
+<Config v="names.product"/> exposes a REST endpoint at the following URL
+to enable API keys:
+<code>https://<Config v="domains.rest.indexing"/>/v1/enable-api-key</code>
 
-### Request Body
+The API Playground shows the full [Enable API Key](/docs/rest-api/enable-api-key) REST definition.
 
-The Enable API Key request body requires the following parameters:
-* `keyID` - Specifies the ID of the API key
-* `enable` - Indicates whether to enable (`true`) or disable (`false`) the API key
+## gRPC Example
 
-
-```json
-{
-  "keyEnablement": [
-    {
-      "keyId": "6o59jjft9o02jtga72pjfv3qpn",
-      "enable": true
-    }
-  ]
-}
-```
+You can find the full Enable API Key gRPC definition at [admin_apikey.proto](https://github.com/vectara/protos/blob/main/admin_apikey.proto).

--- a/www/docs/api-reference/api-keys/enable-api-key.md
+++ b/www/docs/api-reference/api-keys/enable-api-key.md
@@ -12,13 +12,13 @@ import {vars} from '@site/static/variables.json';
 The Enable API Key API lets you enable or disable specific API keys. You 
 can use this endpoint to temporarily disable access without deleting the key.
 
-This capability is useful for scenarios like maintenance windows. or when your 
+This capability is useful for scenarios like maintenance windows, or when your 
 team no longer requires access to a specific corpus.
 
 ## keyEnablement Object
 
 The `keyEnablement` object contains pairs of a `keyID` with the `enable` 
-status as enable (`true`) or disable (`false`) the API key.
+status as `true` or `false` for the API key.
 
 :::tip
 

--- a/www/docs/api-reference/api-keys/list-api-keys.md
+++ b/www/docs/api-reference/api-keys/list-api-keys.md
@@ -9,48 +9,34 @@ import TabItem from '@theme/TabItem';
 import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
-The List API Keys endpoint lists all existing API keys for a customer ID. 
+The List API Keys API lists all existing API keys for a customer ID. 
 It also shows what corpora are accessed by these keys and with what 
-permissions.
+permissions. This capability can provide insights into key usage and 
+status and help you manage the lifecycle and security of your API keys.
 
-This capability can provide insights into key usage and status and help you
-manage the lifecycle and security of your API keys.
+Specify `numResults`, the `pageKey`, and `readCorporaInfo` which indicates whether to 
+return the corpus name and `corpus_id` associated with the API keys.
 
+The response includes a `keyData` object that shows pairs of `apiKey` and 
+`corpus` objects.
 
-## List API Keys Endpoint Address
+:::tip
 
-<Config v="names.product"/> exposes a REST endpoint at the following URL
-to index content into a corpus:
-<code>https://<Config v="domains.rest.indexing"/>/v1/list-api-keys</code>
-
-## List the API Keys from the API Playground
-
-Check out our [interactive API Playground](/docs/rest-api/list-api-keys) that lets 
+Check out our [**interactive API Playground**](/docs/rest-api/list-api-keys) that lets 
 you experiment with this REST endpoint to list API keys in an account.
 
+:::
 
-### Request Headers
+## REST Example
 
-To interact with the List API Keys service via REST calls, you need the 
-following headers:
+### List API Keys Endpoint Address
 
-* `customer_id` is the customer ID to use for the request.
-* An JWT token as your authentication method
+<Config v="names.product"/> exposes a REST endpoint at the following URL
+to list API keys:
+<code>https://<Config v="domains.rest.indexing"/>/v1/list-api-keys</code>
 
+The API Playground shows the full [List API Keys](/docs/rest-api/list-api-keys) REST definition.
 
-### Request Body
+## gRPC Example
 
-The List API Keys request body requires the following parameters:
-* `numResults` - Specifies the maximum number of results to return.
-* `pageKey` Specifies the page key that retrieves a specific page of results. 
-  If you want the first page, leave this field empty.
-* `readCorporaInfo`: Indicates whether to return the corpus name and ID 
-  associated with the API keys.
-
-```json
-{
-  "numResults": 0,
-  "pageKey": "1",
-  "readCorporaInfo": true
-}
-```
+You can find the full List API Keys gRPC definition at [admin_apikey.proto](https://github.com/vectara/protos/blob/main/admin_apikey.proto).

--- a/www/docs/api-reference/chat-apis/delete_conversations.md
+++ b/www/docs/api-reference/chat-apis/delete_conversations.md
@@ -13,35 +13,15 @@ The Delete Conversations API lets you delete conversations from the chat
 history corpus. This is useful for data management to help ensure that you 
 maintain data hygiene and support compliance with data retention policies.
 
+The `conversationId` specifies the IDs of the conversations that you want to  
+delete. The limit is 1000 conversations.
+
 :::tip
 
 Check out our **interactive API Playground** that lets you experiment with this 
 REST endpoint to delete conversations in the chat history corpus.
 
 :::
-
-## Delete Conversations Request and Response
-
-The Delete Conversations request body specifies the `conversationId` that you 
-want to delete.
-
-```json
-{
-  "conversationId": [
-    "0191086a-4b8a-4aec-b600-affa9b261ac"
-  ]
-}
-```
-You get the following response:
-
-```json
-{
-  "status": {
-    "code": 0,
-    "message": ""
-  }
-}
-```
 
 ## REST Example
 
@@ -50,6 +30,8 @@ You get the following response:
 <Config v="names.product"/> exposes an HTTP endpoint at the following URL
 to delete conversations in the chat history corpus:
 <code>https://<Config v="domains.rest.indexing"/>/v1/delete-conversations</code>
+
+The API Playground shows the full [Delete Conversations](/docs/rest-api/delete-conversations) REST definition.
 
 ## gRPC Example
 

--- a/www/docs/api-reference/chat-apis/delete_turns.md
+++ b/www/docs/api-reference/chat-apis/delete_turns.md
@@ -13,38 +13,16 @@ The Delete Turns API deletes specific turns from a conversation within the
 chat history corpus. This enables developers to remove inaccurate or 
 inappropriate responses from the conversation history. 
 
+The `conversationId` specifies the conversation ID that contains the turn 
+you want to delete, and the `turnId` specifies the Turn ID that you want to 
+delete.
+
 :::tip
 
 Check out our **interactive API Playground** that lets you experiment with this 
 REST endpoint to delete turns in specific chats.
 
 :::
-
-## Delete Turns Request and Response
-
-The Delete Turns request body specifies following parameters:
-
-* `conversationId` - Specifies the conversation ID that contains the turn 
-  you want to delete
-* `turnId` - Specifies the Turn ID that you want to delete
-
-```json
-{
-  "conversationId": "0191086a-4b8a-4aec-b600-affa9b261ac",
-  "turnId": "4b8a-4aec-b600"
-}
-```
-
-You get the following response:
-
-```json
-{
-  "status": {
-    "code": 0,
-    "message": ""
-  }
-}
-```
 
 ## REST Example
 
@@ -54,6 +32,7 @@ You get the following response:
 to delete turns in a chat:
 <code>https://<Config v="domains.rest.indexing"/>/v1/delete-turns</code>
 
+The API Playground shows the full [Delete Turns](/docs/rest-api/delete-turns) REST definition.
 
 ## gRPC Example
 

--- a/www/docs/api-reference/chat-apis/disable_turns.md
+++ b/www/docs/api-reference/chat-apis/disable_turns.md
@@ -11,7 +11,11 @@ import {vars} from '@site/static/variables.json';
 
 The Disable Turns API disables specific turns from a conversation within the 
 chat history corpus. This enables developers to exclude specific responses 
-from the conversation history. 
+from the conversation history.
+
+The `conversationId` specifies the conversation ID that contains the turn 
+you want to disable, and the `turnId` specifies the Turn ID that you want to 
+disable.
 
 :::tip
 
@@ -19,33 +23,6 @@ Check out our **interactive API Playground** that lets you experiment with this
 REST endpoint to delete turns in specific chats.
 
 :::
-
-## Disable Turns Request and Response
-
-The Disable Turns request body specifies following parameters:
-
-* `conversationId` - Specifies the conversation ID that contains the turn 
-  you want to disable
-* `turnId` - Specifies the Turn ID that you want to disable
-
-```json
-{
-  "corpus_id": 1,
-  "conversationId": "0191086a-4b8a-4aec-b600-affa9b261ac",
-  "turnId": "4b8a-4aec-b600"
-}
-```
-
-You get the following response:
-
-```json
-{
-  "status": {
-    "code": 0,
-    "message": ""
-  }
-}
-```
 
 ## REST Example
 
@@ -55,6 +32,7 @@ You get the following response:
 to disable turns in a chat:
 <code>https://<Config v="domains.rest.indexing"/>/v1/disable-turns</code>
 
+The API Playground shows the full [Disable Turns](/docs/rest-api/disable-turns) REST definition.
 
 ## gRPC Example
 

--- a/www/docs/api-reference/chat-apis/list_conversations.md
+++ b/www/docs/api-reference/chat-apis/list_conversations.md
@@ -14,12 +14,15 @@ This data enables developers to monitor chatbot interactions and understand
 how users engage with the data. Pagination lets developers navigate through 
 large datasets.
 
-
 ## Conversation Object Definition
 
 The `conversation` object specifies a unique turn `id`, which is the first turn 
 in the conversation. The unique `conversation_id` then specifies the conversation 
 within the chat history corpus. 
+
+The `num_results` (default 5) specifies the maximum number of conversations to 
+return, and `page_key` retrieves a specific page of results. Leave it blank to 
+get the first page.
 
 :::tip
 
@@ -28,44 +31,6 @@ REST endpoint to list conversations in the chat history corpus.
 
 :::
 
-## List Conversations Request and Response
-
-The List Conversations request body has the following parameters:
-
-* `num_results` - Specifies the maximum number of conversations to return. 
-  Default value is 5.
-* `page_key` - Retrieves a specific page of results. You can leave it blank 
-  to get the first page.
-
-```json
-{
-    "num_results": "5",
-    "page_key": "",
-}
-```
-
-You get the following response:
-
-```json
-{
-  "conversation": [
-    {
-      "id": "ID of the turn",
-      "conversation_id": "ID of the conversation",
-      "query": "First query of the turn",
-      "answer": "First answer of the turn",
-      "enabled": true,
-      "epoch_secs": 0
-    }
-  ],
-  "status": {
-    "code": 0,
-    "message": "Status message"
-  },
-  "page_key": ""
-}
-```
-
 ## REST Example
 
 ### List Conversations Endpoint Address
@@ -73,6 +38,8 @@ You get the following response:
 <Config v="names.product"/> exposes an HTTP endpoint at the following URL
 to list conversations in the chat history corpus:
 <code>https://<Config v="domains.rest.indexing"/>/v1/list-conversations</code>
+
+The API Playground shows the full [List Conversations](/docs/rest-api/list-conversations) REST definition.
 
 ## gRPC Example
 

--- a/www/docs/api-reference/chat-apis/read_conversations.md
+++ b/www/docs/api-reference/chat-apis/read_conversations.md
@@ -10,9 +10,15 @@ import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
 The Read Conversations API retrieves detailed information about specific 
-conversations. This information enables developers to analyze the flow of 
-user chats and understand the context of interactions, which helps in 
-refining chatbot responses. You can read up to 100 conversations.
+conversations and chat interactions. This information enables developers to 
+analyze the flow of user chats and understand the context of interactions, 
+which helps in refining chatbot responses. You can read up to 100 
+conversations.
+
+The `conversation_id` specifies the ID of the conversation that you want to read, 
+and it retrieves the `Conversation` object. This object has an `id` and `turn` 
+object which includes the `id` of the turn, `conversationId`, the `query` text, 
+`answer`, and whether the turn is `enabled`.
 
 :::tip
 
@@ -21,55 +27,6 @@ REST endpoint to read conversations in the chat history corpus.
 
 :::
 
-## Read Conversations Request and Response
-
-The Read Conversations request body has the following parameters:
-
-* `conversation_id` - Specifies the ID of the conversation that you want to read
-
-```json
-{
-  "conversation_id": [
-    "0191086a-4b8a-4aec-b600-affa9b261ac"
-  ]
-}
-```
-
-You get the following response:
-
-
-```json
-{
-  "conversation": [
-    {
-      "id": "ID of the conversation",
-      "turn": [
-        {
-          "id": "ID of the turn",
-          "conversation_id": "ID of the conversation",
-          "query": "First query of the turn",
-          "answer": "First answer of the turn",
-          "enabled": true,
-          "epoch_secs": 0
-        },
-        {
-          "id": "ID of the second turn",
-          "conversation_id": "ID of the conversation",
-          "query": "Second query of the turn",
-          "answer": "Second answer of the turn",
-          "enabled": true,
-          "epoch_secs": 0
-        }
-      ]
-    }
-  ],
-  "status": {
-    "code": 0,
-    "message": ""
-  }
-}
-```
-
 ## REST Example
 
 ### Read Conversations Endpoint Address
@@ -77,6 +34,8 @@ You get the following response:
 <Config v="names.product"/> exposes an HTTP endpoint at the following URL
 to read conversations in the chat history corpus:
 <code>https://<Config v="domains.rest.indexing"/>/v1/read-conversations</code>
+
+The API Playground shows the full [Read Conversations](/docs/rest-api/read-conversations) REST definition.
 
 ## gRPC Example
 

--- a/www/docs/api-reference/indexing-apis/core_indexing.md
+++ b/www/docs/api-reference/indexing-apis/core_indexing.md
@@ -72,7 +72,7 @@ The part metadata, held in `metadata_json`, is returned with the document part
 in search query results. For example, it can contain information that links the
 item to records in other systems.
 
-Finally, `custom_dims` allows you to specify additional factors that can be
+For Scale users, `custom_dims` allows you to specify additional factors that can be
 used at query time to control the ranking of results. The dimensions must be
 defined ahead of time for the corpus, or else they'll be ignored.
 
@@ -84,135 +84,19 @@ defined ahead of time for the corpus, or else they'll be ignored.
 to index content into a corpus:
 <code>https://<Config v="domains.rest.indexing"/>/v1/core-index</code>
 
-
-### Low-level Indexing Request and Response
-
-The request body provides the following parameters:
-
-* `customerID`
-* `corpusID`
-* `document` object containing the `documentID`, `metadataJson`, and contextual `parts`
-
-```json
-{
-  "customerId": "123456789",
-  "corpusId": "8",
-  "document": {
-    "documentId": "Research_Doc_1",
-    "metadataJson": "{\"category\":\"Research Papers\"}",
-    "parts": [
-      {
-        "text": "Introduction to Quantum Computing",
-        "context": "Quantum Computing Overview that summarizes the main points of the paper's purpose",
-        "metadataJson": "{\"section\":\"Introduction\"}",
-        "customDims": [
-          {
-            "name": "relevance",
-            "value": 10
-          }
-        ]
-      },
-      {
-        "text": "Quantum Entanglement and Superposition",
-        "context": "Chapter 1: Key Quantum Computing Concepts",
-        "metadataJson": "{\"section\":\"Chapter 1\"}",
-        "customDims": [
-          {
-            "name": "complexity",
-            "value": 15
-          }
-        ]
-      }
-      // Continue with additional parts that you want indexed
-    ],
-    "defaultPartContext": "Quantum Computing Research Study",
-    "customDims": [
-      {
-        "name": "difficulty",
-        "value": 6
-      }
-    ]
-  }
-}
-```
-The response from the server includes a status code and the amount of quota 
-consumed:
-
-```json
-{
-  "status": {
-    "code": "OK",
-    "statusDetail": ""
-  },
-  "quotaConsumed": {
-    "numChars": "1572",
-    "numMetadataChars": "332"
-  }
-}
-
-```
+The API Playground shows the full [Low-level Indexing REST definition](/docs/rest-api/core-index).
 
 ## gRPC Example
 
 You can find the full Low-level Indexing gRPC definition at [indexing_core.proto](https://github.com/vectara/protos/blob/main/indexing_core.proto).
 
-### Index Document Request and Response
-
 A request to add data into a corpus consists of three key pieces of information:
 the customer ID, the corpus ID, and the data itself, represented as a
-**CoreDocument** message.
-
-```protobuf
-message IndexCoreDocumentRequest {
-  // The Customer ID to issue the request for.
-  int64 customer_id = 1;
-  // The Corpus ID to index the document into.
-  int64 corpus_id = 2;
-  com.vectara.indexing.CoreDocument document = 3;
-}
-```
+`CoreDocument` message.
 
 The reply from the server consists of nothing yet. Note that the reply does not
 block. In other words, the information in the request is not yet available in
 the index when the RPC returns.
 
-### Document Container Format
-
-```protobuf
-// A document to index.
-message CoreDocument {
-  // A document ID to assign to this document.
-  string document_id = 1;
-  // Metadata about the document. This should be a json string. It can be
-  // retrieved at query time.
-  string metadata_json = 2;
-  // All parts of this document.
-  repeated CoreDocumentPart parts = 3;
-  // This field provides a way to specify a blanket context for all parts. If
-  // the context in a part is empty, this context will be used.
-  string default_part_context = 4;
-  // A list of custom dimension values that are included in the generated
-  // representation of all parts.
-  repeated CustomDimension custom_dims = 5;
-}
-```
-
-### Part within the Document
-
-```protobuf
-// Part of a document. A document consists of several such parts.
-message CoreDocumentPart {
-  // A part of the document. e.g., a sentence.
-  string text = 1;
-  // Context of the part.
-  string context = 2;
-  // Metadata about this part of the document. This should be a json string.
-  // It is passed through the system, without being used at indexing time. It
-  // can be retrieved at query time.
-  string metadata_json = 3;
-  // A list of custom dimension values that are included in the generated
-  // representation of this part.  These are optional and take on the corpus
-  // default custom dimension value if not explicitly provided for the document
-  repeated CustomDimension custom_dims = 4;
-}
-```
+The full definition also shows the `CoreDocument` container format, which has 
+metadata about the document, and parts within the document as `CoreDocumentPart`.

--- a/www/docs/api-reference/indexing-apis/deleting_documents.md
+++ b/www/docs/api-reference/indexing-apis/deleting_documents.md
@@ -9,7 +9,8 @@ import TabItem from '@theme/TabItem';
 import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
-The Delete Documents API lets you delete a document from a corpus.
+The Delete Documents API lets you delete a document from a corpus. To verify 
+that the document no longer exists in the corpus, use the List Documents endpoint.
 
 :::tip
 
@@ -27,7 +28,7 @@ information:
 * `corpus_id`
 * `document_id`
 
-The reply on successful deletion is `{}`.
+The reply on successful deletion is `{}`. 
 
 
 ## REST Example
@@ -38,22 +39,7 @@ The reply on successful deletion is `{}`.
 to delete content from a corpus:
 <code>https://<Config v="domains.rest.indexing"/>/v1/delete-doc</code>
 
-### Delete Document Request and Response
-
-```json
-{
-  "customerId": "123456789",
-  "corpusId": 1,
-  "documentId": "my_document.docx"
-}
-```
-You get the following response:
-
-```json
-{}
-```
-To verify that the document no longer exists in the corpus, use the 
-List Documents endpoint.
+The API Playground shows the full [Delete Documents REST definition](/docs/rest-api/delete).
 
 ## gRPC Example
 

--- a/www/docs/api-reference/indexing-apis/indexing.md
+++ b/www/docs/api-reference/indexing-apis/indexing.md
@@ -23,9 +23,10 @@ multiple document attributes and metadata.
 
 :::tip
 
-* Check out our [**interactive API Playground**](/docs/rest-api/index) that lets you experiment 
-with this endpoint to index documents from your browser.
-* We also provide REST Index examples in in [**C#**](/docs/getting-started-samples/RestIndexData.cs), [**Java**](/docs/getting-started-samples/RestIndex.java), [**NodeJS**](/docs/getting-started-samples/index_document.js), [**PHP**](/docs/getting-started-samples/indexDocument.php), and [**Python**](/docs/getting-started-samples/rest_index_document.py).
+* Check out our [**interactive API Playground**](/docs/rest-api/index) that shows the full 
+  Index REST definition and lets you experiment with this endpoint to index 
+  documents from your browser.
+* We also provide REST Index examples in [**C#**](/docs/getting-started-samples/RestIndexData.cs), [**Java**](/docs/getting-started-samples/RestIndex.java), [**NodeJS**](/docs/getting-started-samples/index_document.js), [**PHP**](/docs/getting-started-samples/indexDocument.php), and [**Python**](/docs/getting-started-samples/rest_index_document.py).
 
 :::
 
@@ -61,9 +62,10 @@ may optionally speciify a `title`, `description`, and `metadata`. The core of
 the document is also structured in `sections` that can include unique 
 identifiers, titles, strings, metadata, and so on. 
 
-The `custom_dims` field provides default values for the corresponding
-section fields, should they fail to define them explicitly. Most importantly, 
-`section` defines the actual textual matter.
+The `custom_dims` field (Scale only) provides default values for the 
+corresponding section fields, should they fail to define them explicitly. 
+Most importantly, `section` defines the actual textual matter. Documents can 
+also have multiple sections.
 
 ### Section within a Document
 
@@ -115,9 +117,10 @@ The part metadata, held in `metadata_json`, is returned in search query
 results. It can contain, for example, information that links the item to records
 in other systems.
 
-Finally, `custom_dims` allows you to specify additional factors that can be
-used at query time to control the ranking of results. The dimensions must be
-defined ahead of time for the corpus, or else they'll be ignored.
+For Scale only users, `custom_dims` allows you to specify additional factors 
+that can be used at query time to control the ranking of results. The 
+custom dimensions must be defined ahead of time for the corpus, or else 
+they'll be ignored.
 
 ## REST Example
 
@@ -127,157 +130,25 @@ defined ahead of time for the corpus, or else they'll be ignored.
 to index content into a corpus:
 <code>https://<Config v="domains.rest.indexing"/>/v1/index</code>
 
-### Index Request and Response
+The API Playground shows the full [Standard Indexing REST definition](/docs/rest-api/index).
 
-The request body provides essential information about the document you want to
-index. The Index request requires the following parameters:
-
-* `customerID`
-* `corpusID`
-* `document` object
-
-
-```json
-{
-  "customerId": 123456789,
-  "corpusId": 5,
-  "document": {
-    "documentId": "issbn-9781405053976",
-    "title": "The Hitchhiker's Guide to the Galaxy",
-    "description": "A great book with the answer to life, the universe, and everything",
-    "metadataJson": "{\"author\": \"Douglas Adams\"}",
-    "section": [
-      {
-        "title": "Intro",
-        "text": "Far out in the uncharted backwaters of the unfashionable end of the western spiral arm of the Galaxy lies a small unregarded yellow sun.",
-        "metadataJson": "{\"page\": 1}"
-      },
-      {
-        "title": "The answer",
-        "text": "The Answer to the Great Question ... Of Life, the Universe and Everything ... Is ... Forty-two.",
-        "metadataJson": "{\"speaker\": \"Deep Thought\"}"
-      }
-    ]
-  }
-}
-```
-The response from the server includes a status code and the amount of quota
-consumed:
-
-```json
-{
-  "status": {
-    "code": "OK",
-    "statusDetail": "",
-    "cause": null
-  },
-  "quotaConsumed": {
-    "numChars": "348",
-    "numMetadataChars": "469"
-  }
-}
-```
 ## gRPC Example 
 
 You can find the full Standard Indexing gRPC definition at [indexing.proto](https://github.com/vectara/protos/blob/main/indexing.proto).
 
-### Index Document Request and Response
+For `IndexDocumentRequest`, the reply does not block. The information in the request 
+is not necessarily available in the 
+index when the RPC returns. In most cases, it becomes available within a second.
 
-<pre>{`
-message IndexDocumentRequest {
-  int64 customer_id = 1;
-  int64 corpus_id = 2;
-  ${vars['package.protobuf']}.indexing.Document document = 3;
-}
-`}</pre>
-
-:::note
-
-The reply does not block. The information in the request is not necessarily 
-available in the index when the RPC returns. In most cases, it becomes 
-available within a second.
-
-:::
-
-Here is an example response:
-
-```protobuf
-message IndexDocumentResponse {
-  // If ALREADY_EXISTS, it means the document was already indexed, and no new
-  // quota was consumed.
-  Status status = 1;
-
-  // The storage quota needed for the document indexed in the request.
-  // If "status" is ALREADY_EXISTS, it means that the document was already in
-  // the index prior to this request. In such cases, quota is not consumed again
-  // and the value in this field represents the quota consumed when the document
-  // was indexed the first time.
-  StorageQuota quota_consumed = 2;
-}
-```
-
-```protobuf
-message StorageQuota {
-  // The number of chars from the document that consumed the storage quota.
-  int64 num_chars = 1;
-  // The number of chars in the metadata of the document that consumed the
-  // storage quota.
-  int64 num_metadata_chars = 2;
-}
-```
-### Document Format
-
-```protobuf
-message Document {
-  // Client assigned document ID to this document.
-  string document_id = 1;
-  // The title of the document.
-  string title = 2;
-  // An optional description for the document.
-  string description = 3;
-  // Metadata about the document. This should be a json string, and it can be
-  // retrieved at query time.
-  string metadata_json = 4;
-  // A list of custom dimension values that are included in the generated
-  // representation of all sections.
-  repeated CustomDimension custom_dims = 5;
-
-  // The actual content of the document, structured as a repeating list
-  // of sections.
-  repeated Section section = 10;
-}
-
-```
-
-### Section within a Document
-
-```protobuf
-message Section {
-  // Optionally, the unique ID of this section. If set, it will be returned as
-  // metadata in query results.
-  int32 id = 1;
-  // Optionally, the title of the section. This may be empty.
-  string title = 2;
-  // The text of the section. This should never be empty.
-  string text = 3;
-  // Metadata about this section. This should be a json string. It is passed
-  // through the system, without being used at indexing time. It can be
-  // retrieved at query time.
-  string metadata_json = 4;
-  // A list of custom dimension values that are included in the generated
-  // representation of all subsections (i.e. sections contains by this section).
-  repeated CustomDimension custom_dims = 5;
-
-  // A list of subsections.
-  repeated Section section = 10;
-}
-```
+The full definition also shows the `Document` format, and a `Section` within 
+the document, including metadata about the section.
 
 ### Custom Dimensions Use Cases (Scale only)
 
-Custom dimensions are a powerful <Config v="names.product"/> capability. Custom
-dimensions enable you to attach numeric factors to every item in the index,
-which affect its final ranking during searches. Some example use cases include:
+Custom dimensions are a powerful <Config v="names.product"/> capability for 
+our Scale users. Custom dimensions enable you to attach numeric factors to 
+every item in the index, which affect its final ranking during searches. Some 
+example use cases include:
 
 1. Define the authoritativeness of the content.
 
@@ -295,13 +166,6 @@ which affect its final ranking during searches. Some example use cases include:
 3. Define the geography in which content is relevant.
 4. Indicate the publication date which makes it easy to weight more recent
    results higher.
-
-```protobuf
-message CustomDimension {
-  string name = 1;
-  double value = 2;
-}
-```
 
 For more information on how to use custom dimensions, refer to the
 [Custom Dimensions Usage Documentation](/docs/learn/semantic-search/add-custom-dimensions)

--- a/www/docs/api-reference/search-apis/search.md
+++ b/www/docs/api-reference/search-apis/search.md
@@ -1,7 +1,7 @@
 ---
 id: search
-title: Search API Definition
-sidebar_label: Search API Definition
+title: Query API Definition
+sidebar_label: Query API Definition
 ---
 
 import Tabs from '@theme/Tabs';
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 import {Config} from '@site/docs/definitions.md';
 import {vars} from '@site/static/variables.json';
 
-The Search endpoint lets you perform a query while defining its parameters 
+The Query API lets you perform a query while defining its parameters 
 that specify the query text, pagination details, metadata filters, and other 
 settings that enable application builders to tailor their queries to specific 
 use cases.
@@ -21,7 +21,8 @@ filtering, reranking, Retrieval Augmented Generation (RAG), and hybrid search.
 
 :::tip
 
-Check out our [**interactive API Playground**](/docs/rest-api/query) that lets you experiment with this REST endpoint to manage your corpus details.
+Check out our [**interactive API Playground**](/docs/rest-api/query) that lets you experiment 
+with this REST endpoint to manage your corpus details.
 
 :::
 
@@ -118,7 +119,7 @@ The [Vectara Chat APIs](/docs/api-reference/chat-apis/chat-apis-overview) have m
 to search content from a corpus:
 <code>https://<Config v="domains.rest.serving"/>/v1/query</code>
 
-The API Playground shows the full [Query REST definition]((/docs/rest-api/query)).
+The API Playground shows the full [Query REST definition](/docs/rest-api/query).
 
 ## gRPC Example
 

--- a/www/docs/api-reference/search-apis/search.md
+++ b/www/docs/api-reference/search-apis/search.md
@@ -108,6 +108,8 @@ citing the results as references. For more information, read about [Retrieval Au
 The `summary` within the query can also contain a conversation from [Vectara Chat](/docs/api-reference/chat-apis/chat-apis-overview) which 
 includes a `conversationId`. You enable Vectara Chat by setting the `store` value to `true`.
 
+The [Vectara Chat APIs](/docs/api-reference/chat-apis/chat-apis-overview) have more details about conversations.
+
 ## REST Example
 
 ### Query API Endpoint Address
@@ -116,90 +118,18 @@ includes a `conversationId`. You enable Vectara Chat by setting the `store` valu
 to search content from a corpus:
 <code>https://<Config v="domains.rest.serving"/>/v1/query</code>
 
-### Query Request Headers
-
-To interact with the Query service via REST calls, you need the following 
-headers:
-
-* `customer_id` is the customer ID to use for the request.
-* An API Key or JWT token is your authentication method
-* (Optional) `grpc-timeout` lets you specify how long to wait for queries that 
-  have the potential to take longer to process. We recommend 
-  `-H "grpc-timeout: 30S"`
-
-### Query Request
-
-The Query request body specifies different parameters that ask questions about 
-the data within corpora. The Query request requires the following parameters:
-
-* `query` - Contains your question and number of results to return.
-* `corpusKey` - Specifies which corpora to run the query. For multiple corpora, 
-  use an array
-
-```json
-{
-  "query": [
-    {
-      "query": "What is the answer to the life, the universe, and everything?",
-      "start": 0,
-      "numResults": 10,
-      "contextConfig": {
-        "charsBefore": 30,
-        "charsAfter": 30,
-        "sentencesBefore": 3,
-        "sentencesAfter": 3,
-        "startTag": "<b>",
-        "endTag": "</b>"
-      },
-      "corpusKey": [
-        {
-          "customerId": 123456789,
-          "corpusId": 1,
-          "semantics": "DEFAULT",
-          "dim": [],
-          "metadataFilter": "part.lang = 'eng'",
-          "lexicalInterpolationConfig": {
-            "lambda": 0.025
-          }
-        }
-      ],
-      "rerankingConfig": {
-        "rerankerId": 272725718,
-        "mmrConfig": {
-          "diversityBias": 0
-        }
-      },
-      "summary": [
-        {
-          "summarizerPromptName": "vectara-summary-ext-v1.2.0",
-          "maxSummarizedResults": 5,
-          "responseLang": "eng",
-          "chat": {
-            "store": true,
-            "conversationId": "0191086a-4b8a-4aec-b600-affa9b261acf"
-          },
-        }
-      ]
-    }
-  ]
-}
-```
+The API Playground shows the full [Query REST definition]((/docs/rest-api/query)).
 
 ## gRPC Example
 
 You can find the full Query gRPC definition at [serving.proto](https://github.com/vectara/protos/blob/main/serving.proto).
 
-### Query Service
+### Query Service and Request
 
-Fundamentally, the system accepts a query and returns a response, which contains
-a list of results. However, for efficiency, one or more queries can be batched
-into a single request.
-
-### Query Request
-
-The request provides several fields and nested messages that configure the 
-query, its context, and how the results should be processed and presented.
-The `query` contains the search terms that the system needs to match against 
+The definition shows details about the `query` service. The system accepts a 
+`query` and returns a response, which contains a list of results. For 
+efficiency, one or more queries can be batched into a single request. `query` 
+contains the search terms that the system needs to match against 
 the data. Then `ContextConfig` specifies the amount of text or number of 
 sentences before and after the result snippet.
 
@@ -232,8 +162,8 @@ may be less than the length of the response list.
 
 #### Attribute
 
-Attribute represents a named piece of metadata. Both the **name** and its
-**value** are string typed.
+Attribute represents a named piece of metadata. Both the `name` and its
+`value` are string typed.
 
 ```
 message Attribute {


### PR DESCRIPTION
Updated the REST and gRPC example sections with links to the playground and protos and general cleanup of these topics.