### PR TITLE
fix: Only execute analytics page function if it is available.

### DIFF
--- a/www/static/routeUpdateModule.js
+++ b/www/static/routeUpdateModule.js
@@ -1,10 +1,7 @@
-
 export function onRouteDidUpdate({ location, previousLocation }) {
   // Don't execute if we are still on the same page; the lifecycle may be fired
   // because the hash changes (e.g. when navigating between headings)
   if (location.pathname !== previousLocation?.pathname) {
-    if (window.analytics) {
-      window.analytics.page();
-    }
+    window.analytics?.page?.();
   }
-};
+}


### PR DESCRIPTION
## CONTEXT

The window.analytics.page function needs to execute when the user navigates to a new page in the docs site. However, when the user navigates to a specific page (i.e. deeplink), the function attempts to fire before it is defined.

## CHANGE
- Use optional chaining to only execute `window.analytics.page` if it is defined.