### PR TITLE
chore: Point ReactSearch to updated reranker

### DIFF
--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -11,7 +11,7 @@
         "@docusaurus/core": "2.4.3",
         "@docusaurus/preset-classic": "2.4.3",
         "@mdx-js/react": "^1.6.22",
-        "@vectara/react-search": "^1.0.0",
+        "@vectara/react-search": "^1.1.0",
         "classnames": "^2.3.2",
         "clsx": "^1.2.1",
         "docusaurus": "^1.14.7",
@@ -3876,9 +3876,9 @@
       "license": "MIT"
     },
     "node_modules/@vectara/react-search": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@vectara/react-search/-/react-search-1.0.0.tgz",
-      "integrity": "sha512-jPdHM/0eYwDK1KRafwjJJTNf3M+yf17PRomHJpxW1hEiJXCdxt1S7JK15UP6clB11jfMo+zSuDnu6dVwr+I1Ug==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@vectara/react-search/-/react-search-1.1.0.tgz",
+      "integrity": "sha512-ot5PG+02L1frb8l5UThJbMK//4VvxjIpPtwrQoQFh2Ppt5whKcpheo6l2Df5kvJS1g6tmg4uNc1XK8cjwbMVqA==",
       "dependencies": {
         "@testing-library/react-hooks": "^8.0.1",
         "@types/react": "^17.0.0",

--- a/www/package.json
+++ b/www/package.json
@@ -18,7 +18,7 @@
     "@docusaurus/core": "2.4.3",
     "@docusaurus/preset-classic": "2.4.3",
     "@mdx-js/react": "^1.6.22",
-    "@vectara/react-search": "^1.0.0",
+    "@vectara/react-search": "^1.1.0",
     "classnames": "^2.3.2",
     "clsx": "^1.2.1",
     "docusaurus": "^1.14.7",

--- a/www/src/theme/SearchBar.tsx
+++ b/www/src/theme/SearchBar.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import BrowserOnly from "@docusaurus/BrowserOnly";
 
-const CUSTOMER_ID = "3874164736";
-const CORPUS_ID = "1";
-const API_KEY = "zqt_5usQAFwTytdQHAXn17Iq31OQMA5RrIBWLI7Fwg";
+const CUSTOMER_ID = "1526022105";
+const CORPUS_ID = "232";
+const API_KEY = "zqt_WvU_2ewh7ZGRwq8LdL2SV8B9RJmVGyUm1VAuOw";
 
 export default function SearchBar() {
   return (
@@ -34,6 +34,7 @@ export default function SearchBar() {
             isSummaryToggleInitiallyEnabled={
               isSummaryToggleInitiallyEnabled === "true"
             }
+            rerankingConfiguration={{ rerankerId: 272725719 }}
           />
         );
       }}


### PR DESCRIPTION
## CONTEXT

We need to configure docs search to use the latest reranker

## CHANGES
- Add rerank configuration to ReactSearch
- Point ReactSearch to docs corpus used for demos.