### PR TITLE
Wrap tabs in API reference so they don't get clipped.

### DIFF
--- a/www/src/css/custom.css
+++ b/www/src/css/custom.css
@@ -540,6 +540,8 @@ h1
 .tabs {
   border-bottom: 1px solid #cbcdde;
   overflow: initial;
+  /* Prevent tabs from being clipped when there are many of them. */
+  flex-wrap: wrap;
 }
 
 .tabs__item {


### PR DESCRIPTION
## Before

![image](https://github.com/vectara/vectara-docs/assets/1238659/40a058e5-1446-4bdd-a311-55c180eae70b)

## After

![image](https://github.com/vectara/vectara-docs/assets/1238659/cbd9cf48-b3e4-4590-b14a-5729f5c290eb)
