### PR TITLE
Update Python-SDK push logic from Fern

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -43,8 +43,6 @@ groups:
             unions: v1
         github:
           repository: vectara/python-sdk
-          mode: push
-          branch: fern-bot/09-30-2024-0640AM
         config:
           extra_dependencies:
             PyYAML: '6.0.2'


### PR DESCRIPTION
removed specific branch push so that releasing Python-SDK will push a new version to PyPi