### PR TITLE
feat(new): Add documentation for the new Update and Replace Metadata API Definitions

### DIFF
--- a/www/docs/api-reference/admin-apis/create-corpus.md
+++ b/www/docs/api-reference/admin-apis/create-corpus.md
@@ -48,9 +48,10 @@ corpus. The `name` does not need to be unique within an account.
 
 ## Filter Attribute
 
-In order to reference metadata in [filter expressions](/docs/learn/metadata-search-filtering/filter-overview), the
-referenceable attributes must be declared at creation time in the **filter
-attributes**. This list cannot be changed once the corpus is created.
+In order to reference metadata in [filter expressions](/docs/learn/metadata-search-filtering/filter-overview), you
+declare the referenceable attributes at creation time in the **filter
+attributes**. If you already created a corpus, use the 
+[Replace Filter Attributes API](/docs/api-reference/admin-apis/corpus/replace-filter-attributes). 
 
 Filter attributes allow you to attach metadata to your data at the document (`doc`) 
 or `part` level, which you can use later in filter expressions to narrow the scope 

--- a/www/docs/api-reference/admin-apis/create-corpus.md
+++ b/www/docs/api-reference/admin-apis/create-corpus.md
@@ -49,9 +49,8 @@ corpus. The `name` does not need to be unique within an account.
 ## Filter Attribute
 
 In order to reference metadata in [filter expressions](/docs/learn/metadata-search-filtering/filter-overview), you
-declare the referenceable attributes at creation time in the **filter
-attributes**. If you already created a corpus, use the 
-[Replace Filter Attributes API](/docs/api-reference/admin-apis/corpus/replace-filter-attributes). 
+must define the **filter attributes** at the time of corpus creation. If you 
+already created a corpus, use the [Replace Filter Attributes API](/docs/api-reference/admin-apis/corpus/replace-filter-attributes). 
 
 Filter attributes allow you to attach metadata to your data at the document (`doc`) 
 or `part` level, which you can use later in filter expressions to narrow the scope 

--- a/www/docs/api-reference/indexing-apis/replace-document-metadata.md
+++ b/www/docs/api-reference/indexing-apis/replace-document-metadata.md
@@ -1,0 +1,40 @@
+---
+id: replace-document-metadata
+title: Replace Document Metadata API Definition
+sidebar_label: Replace Document Metadata API Definition
+---
+
+import {Config} from '@site/docs/definitions.md';
+import {vars} from '@site/static/variables.json';
+
+The Replace Document Metadata API enables you to overwrite the metadata of a 
+specific document in a corpus. This endpoint replaces the existing metadata 
+object entirely with a new metadata object provided in the request. It is 
+useful when you want to reset or standardize metadata fields for a document.
+
+Replacing document metadata ensures that only the fields specified in the new 
+metadata object are retained, and all existing metadata fields are replaced.
+
+This operation is particularly helpful for maintaining metadata consistency or 
+when significant changes are required in a document's metadata.
+
+## Replace Document Metadata Request and Response
+
+To replace a document’s metadata, send a `PUT` request to 
+`/v2/corpora/:corpus_key/documents/:document_id/metadata`, where:
+
+`corpus_key` is the unique identifier of the corpus containing the document.
+`document_id` is the unique identifier for the document. This ID must be percent-encoded.
+
+The request body must contain the new metadata object. This object replaces 
+all fields in the existing metadata.
+
+## REST 2.0 URL
+
+### Replace Corpus Document Metadata REST Endpoint Address
+
+Vectara exposes a REST endpoint at the following URL to replace document 
+metadata:
+<code>https://<Config v="domains.rest.admin"/>/v2/corpora/:corpus_key/documents/:document_id/metadata</code>
+
+The API Reference shows the full [Replace Document Metadata](/docs/rest-api/replace-corpus-document-metadata) REST definition.

--- a/www/docs/api-reference/indexing-apis/replace-document-metadata.md
+++ b/www/docs/api-reference/indexing-apis/replace-document-metadata.md
@@ -13,7 +13,7 @@ object entirely with a new metadata object provided in the request. It is
 useful when you want to reset or standardize metadata fields for a document.
 
 Replacing document metadata ensures that only the fields specified in the new 
-metadata object are retained, and all existing metadata fields are replaced.
+metadata object are retained, and all previous metadata fields are replaced.
 
 This operation is particularly helpful for maintaining metadata consistency or 
 when significant changes are required in a document's metadata.

--- a/www/docs/api-reference/indexing-apis/update-document-metadata.md
+++ b/www/docs/api-reference/indexing-apis/update-document-metadata.md
@@ -1,0 +1,42 @@
+---
+id: update-document-metadata
+title: Update Document Metadata API Definition
+sidebar_label: Update Document Metadata API Definition
+---
+
+import {Config} from '@site/docs/definitions.md';
+import {vars} from '@site/static/variables.json';
+
+The Update Document Metadata API enables you to modify the metadata of a 
+specific document in a corpus by merging the new metadata with the existing 
+metadata. This operation allows you to add or update specific fields without 
+affecting other metadata fields.
+
+Updating document metadata ensures that existing metadata fields not specified 
+in the request remain unchanged. This is useful for incremental updates, such 
+as adding new tags or updating specific attributes of a document.
+
+This operation is ideal for scenarios where metadata changes are additive or 
+require only partial updates to specific fields.
+
+## Update Corpus Document Metadata Request and Response
+
+To update a document’s metadata, send a `PATCH` request to 
+`/v2/corpora/:corpus_key/documents/:document_id`, where:
+
+`corpus_key` is the unique identifier of the corpus containing the document.
+`document_id` is the unique identifier for the document. This ID must be percent-encoded.
+
+The request body must include the metadata fields to add or update. Only the 
+specified fields will be modified; all other metadata fields will remain 
+unchanged.
+
+## REST 2.0 URL
+
+### Update Corpus Document Metadata REST Endpoint Address
+
+Vectara exposes a REST endpoint at the following URL to update document 
+metadata:
+<code>https://<Config v="domains.rest.admin"/>/v2/corpora/:corpus_key/documents/:document_id</code>
+
+The API Reference shows the full [Update Document Metadata](/docs/rest-api/list-corpus-documents) REST definition.

--- a/www/docs/api-reference/rest.md
+++ b/www/docs/api-reference/rest.md
@@ -61,6 +61,7 @@ real-time API calls from your browser.
 Vectara provides the following REST 2.0 endpoints:
 
 ### Request timeouts
+
 By default, requests will take as long as they need to complete.  However, you
 can request a maximum time for most of the APIs to take by specifying the
 `Request-Timeout` or `Request-Timeout-Millis` parameters in the HTTP headers.
@@ -115,7 +116,10 @@ The following endpoints help you index, upload files, and manage documents:
 - [File Upload API](/docs/api-reference/indexing-apis/file-upload/file-upload): Upload files to a corpus for automatic parsing
   and document extraction.
 - [List Documents API](/docs/api-reference/admin-apis/corpus/list-documents): Retrieve a list of documents in a specific corpus.
+- [Retrieve Document API](/docs/api-reference/admin-apis/corpus/retrieve-document): Retrieve the content and metadata of a specific document.
 - [Delete Document API](/docs/api-reference/indexing-apis/deleting-documents): Remove a document from a corpus.
+- [Update Document Metadata API](/docs/api-reference/indexing-apis/update-document-metadata): Update the metadata of a document in a corpus.
+- [Replace Document Metadata API](/docs/api-reference/indexing-apis/replace-document-metadata): Completely replace the metadata of a document.
 
 ### Chats
 

--- a/www/docs/learn/metadata-search-filtering/overview.md
+++ b/www/docs/learn/metadata-search-filtering/overview.md
@@ -45,16 +45,17 @@ When indexing data in Vectara, you associate metadata at these levels:
 
 ## Setting up metadata filters
 
-To use metadata filters, you must first configure filter attributes when 
-[creating][4] or updating a corpus. These filter attributes define the metadata 
-fields that queries can filter on.
+To use metadata filters, you must configure [filter attributes][4] for your corpus. 
+Filter attributes define the metadata fields that queries can filter on. You 
+can do this in the following ways:
 
-* You can define metadata filters as part of the corpus creation process using 
-  the `filter_attributes` parameter.
-* To add or modify metadata filters for an existing corpus, use the 
-  [Update Document API](/docs/api-reference/indexing-apis/update-document-metadata). This request adds or updates a filter for the 
-  `publication_date` attribute at the document level.
-* To replace the metadata entirely, use the [Replace Document Metadata API](/docs/api-reference/indexing-apis/replace-document-metadata).
+* **During corpus creation:** Use the `filter_attributes` parameter when creating a 
+  corpus with the [Vectara Console](/docs/console-ui/creating-a-corpus) or [API][4].
+* **For an existing corpus:**
+  * Use the [Update Document Metadata API](/docs/api-reference/indexing-apis/update-document-metadata) to add or update specific metadata 
+  fields for a corpus at the document level.
+  * Use the [Replace Document Metadata API](/docs/api-reference/indexing-apis/replace-document-metadata) to entirely replace the existing 
+  metadata for a document.
 
 :::note
 Updating or replacing metadata is limited only to document-level metadata.

--- a/www/docs/learn/metadata-search-filtering/overview.md
+++ b/www/docs/learn/metadata-search-filtering/overview.md
@@ -49,8 +49,8 @@ To use metadata filters, you must configure [filter attributes][4] for your corp
 Filter attributes define the metadata fields that queries can filter on. You 
 can do this in the following ways:
 
-* **During corpus creation:** Use the `filter_attributes` parameter when creating a 
-  corpus with the [Vectara Console](/docs/console-ui/creating-a-corpus) or [API][4].
+* **During corpus creation:** Use the `filter_attributes` parameter when [creating a 
+  corpus][4].
 * **For an existing corpus:**
   * Use the [Update Document Metadata API](/docs/api-reference/indexing-apis/update-document-metadata) to add or update specific metadata 
   fields for a corpus at the document level.

--- a/www/docs/learn/metadata-search-filtering/overview.md
+++ b/www/docs/learn/metadata-search-filtering/overview.md
@@ -43,9 +43,22 @@ When indexing data in Vectara, you associate metadata at these levels:
       * `part.section = 'Introduction'`
       * `part.clause_type = 'Liability' AND part.risk_level = 25 AND part.is_boilerplate = false`
 
+## Setting up metadata filters
 
-To learn more about setting up filterable metadata review the [filter attribute][4] 
-section of the corpus creation documentation.
+To use metadata filters, you must first configure filter attributes when 
+[creating][4] or updating a corpus. These filter attributes define the metadata 
+fields that queries can filter on.
+
+* You can define metadata filters as part of the corpus creation process using 
+  the `filter_attributes` parameter.
+* To add or modify metadata filters for an existing corpus, use the 
+  [Update Document API](/docs/api-reference/indexing-apis/update-document-metadata). This request adds or updates a filter for the 
+  `publication_date` attribute at the document level.
+* To replace the metadata entirely, use the [Replace Document Metadata API](/docs/api-reference/indexing-apis/replace-document-metadata).
+
+:::note
+Updating or replacing metadata is limited only to document-level metadata.
+:::
 
 ## Use cases for metadata filtering
 

--- a/www/docs/release-notes.mdx
+++ b/www/docs/release-notes.mdx
@@ -17,6 +17,33 @@ experimenting with Retrieval Augmented Generation (RAG), or exploring our
 newest API endpoints, this page is your go-to place to see how we’re evolving 
 and how these product and documentation changes can benefit your enterprise.
 
+## Update or replace document metadata
+
+_December 13, 2024_
+
+Vectara now enables users to update document metadata without reindexing. This 
+capability supports two distinct operations: merging new metadata into 
+existing metadata or replacing the metadata entirely. Both operations are 
+now available through dedicated API endpoints.
+
+**Why it matters:** Managing metadata is a critical part of ensuring that search 
+and retrieval systems reflect the most up-to-date information. The ability to 
+merge new metadata incrementally enables users to add or adjust specific 
+fields without affecting existing data, while the full replacement operation 
+is ideal for scenarios requiring a clean update. By streamlining metadata 
+updates without reindexing document content, this feature enhances 
+efficiency and ensures smooth document lifecycle management.
+
+**New endpoints:**
+* Update Metadata
+* Replace Metadata
+
+**More information:**
+
+* Update Metadata API Definition
+* Replace Metadata API Definition
+
+
 ## Querying table data
 
 _December 10, 2024_

--- a/www/docs/release-notes.mdx
+++ b/www/docs/release-notes.mdx
@@ -19,7 +19,7 @@ and how these product and documentation changes can benefit your enterprise.
 
 ## Update or replace document metadata
 
-_December 13, 2024_
+_December 17, 2024_
 
 Vectara now enables users to update document metadata without reindexing. This 
 capability supports two distinct operations: merging new metadata into 
@@ -35,13 +35,14 @@ updates without reindexing document content, this feature enhances
 efficiency and ensures smooth document lifecycle management.
 
 **New endpoints:**
-* Update Metadata
-* Replace Metadata
+* [Update Metadata](/docs/rest-api/update-corpus-document)
+* [Replace Metadata](/docs/rest-api/replace-corpus-document-metadata)
 
 **More information:**
 
-* Update Metadata API Definition
-* Replace Metadata API Definition
+* [Metadata Filters](/docs/learn/metadata-search-filtering/filter-overview)
+* [Update Metadata API Definition](/docs/api-reference/indexing-apis/update-document-metadata)
+* [Replace Metadata API Definition](/docs/api-reference/indexing-apis/replace-document-metadata)
 
 
 ## Querying table data

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -327,7 +327,11 @@ module.exports = {
         {
           type: "category",
           label: "Indexing APIs",
-          items: ["api-reference/indexing-apis/indexing"],
+          items: [
+            "api-reference/indexing-apis/indexing",
+            "api-reference/indexing-apis/update-document-metadata",
+            "api-reference/indexing-apis/replace-document-metadata",
+          ],
         },
         {
           type: "category",


### PR DESCRIPTION
Added new topics about updating and replacing metadata without reindexing. Both operations are now available through two new endpoints.