### PR TITLE
fix: format streaming as `sse`

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "vectara",
-  "version": "0.45.0-rc47"
+  "version": "0.46.5"
 }

--- a/fern/openapi-overrides.yaml
+++ b/fern/openapi-overrides.yaml
@@ -187,6 +187,7 @@ paths:
     post:
       x-fern-streaming: 
         stream-condition: $request.stream_response
+        format: sse
         response:
           $ref: "#/components/schemas/QueryFullResponse"
         response-stream:
@@ -224,6 +225,7 @@ paths:
       x-fern-sdk-method-name: search
     post:
       x-fern-streaming: 
+        format: sse
         stream-condition: $request.stream_response
         response:
           $ref: "#/components/schemas/QueryFullResponse"
@@ -256,6 +258,7 @@ paths:
         results: $response.chats
     post:
       x-fern-streaming:
+        format: sse
         stream-condition: $request.stream_response
         response:
           $ref: "#/components/schemas/ChatFullResponse"
@@ -283,6 +286,7 @@ paths:
       x-fern-sdk-method-name: listTurns
     post:
       x-fern-streaming: 
+        format: sse
         stream-condition: $request.stream_response
         response:
           $ref: "#/components/schemas/ChatFullResponse"

--- a/fern/openapi-overrides.yaml
+++ b/fern/openapi-overrides.yaml
@@ -214,11 +214,13 @@ paths:
             stream_response: true
           response:
             stream:
-              - type: search_results
-                search_results: 
-                  - text: "Hello, world!"
-                    score: 0.9
-                    document_id: "doc_123"
+              - event: search_results
+                data: 
+                  type: search_results
+                  search_results: 
+                    - text: "Hello, world!"
+                      score: 0.9
+                      document_id: "doc_123"
   /v2/corpora/{corpus_key}/query:
     get:
       x-fern-sdk-group-name: corpora


### PR DESCRIPTION
We need to communicate to Fern that our streaming endpoints are SSE (https://buildwithfern.com/learn/api-definition/openapi/endpoints/sse#server-sent-events)