### PR TITLE
docs(fix): Fix broken links in generative prompts

### DIFF
--- a/www/docs/generative-prompts.mdx
+++ b/www/docs/generative-prompts.mdx
@@ -18,7 +18,7 @@ and effective outputs for complex scenarios.
 <Grid columns={3}>
   <TopicButton
     title="Vectara Prompt Engine"
-    href="/docs/learn/generative-prompts/vectara-prompt-engine">
+    href="/docs/prompts/vectara-prompt-engine">
     <Spacer size="l" />
     Empower your applications with customizable prompt templates.
     <Spacer size="l" />
@@ -28,7 +28,7 @@ and effective outputs for complex scenarios.
   
   <TopicButton
     title="Custom Prompts with Metadata"
-    href="/docs/learn/generative-prompts/custom-prompts">
+    href="/docs/prompts/custom-prompts-with-metadata">
     <Spacer size="l" />
     Unlock powerful customization options by integrating metadata directly into 
     your prompts.

--- a/www/docusaurus.config.js
+++ b/www/docusaurus.config.js
@@ -301,15 +301,15 @@ ${content}
           items: [
             {
               label: "About",
-              to: "https://vectara.com/about-vectara/",
+              to: "https://www.vectara.com/company/about-us/",
             },
             {
               label: "Careers and Culture",
-              to: "https://vectara.com/careers/",
+              to: "https://www.vectara.com/company/careers-and-culture/",
             },
             {
               label: "Contact Us",
-              to: "https://vectara.com/contact-us/",
+              to: "https://www.vectara.com/contact-us/",
             },
           ],
         },
@@ -318,19 +318,19 @@ ${content}
           items: [
             {
               label: "Trust and Security",
-              href: "https://vectara.com/legal/security-at-vectara/",
+              href: "https://www.vectara.com/legal/security-at-vectara/",
             },
             {
               label: "Privacy Policy",
-              href: "https://vectara.com/legal/privacy-policy/",
+              href: "https://www.vectara.com/legal/privacy-policy/",
             },
             {
               label: "Terms",
-              href: "https://vectara.com/legal/terms-of-service/",
+              href: "https://www.vectara.com/legal/terms-of-service/",
             },
             {
               label: "FAQs",
-              href: "https://vectara.com/faqs/",
+              href: "https://www.vectara.com/faqs/",
             },
           ],
         },
@@ -339,15 +339,15 @@ ${content}
           items: [
             {
               label: "LinkedIn",
-              href: "https://linkedin.com/company/vectara",
+              href: "https://www.linkedin.com/company/vectara/",
             },
             {
               label: "Facebook",
               href: "https://www.facebook.com/vectara/",
             },
             {
-              label: "Twitter",
-              href: "https://twitter.com/vectara",
+              label: "X",
+              href: "https://x.com/vectara",
             },
             {
               label: "Youtube",


### PR DESCRIPTION
Fixes #390 

Also updates links to the product site in the docusaurus config.