### PR TITLE
Fix bug in which nav items overlap when window is narrower.

### DIFF
--- a/www/src/css/custom.css
+++ b/www/src/css/custom.css
@@ -20,6 +20,11 @@
 
 /* Navbar for search */
 
+.navbar__items {
+  /* Prevent items from overlapping as window gets narrower. */
+  flex: none;
+}
+
 .navbar__items--right {
   flex-grow: 1;
 }


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/7eb6349e-f0bb-40e7-9af3-929c472e960d)

After:
![image](https://github.com/user-attachments/assets/5811fadb-bf83-425a-8b24-42c5aae86663)
