### PR TITLE
fix(config): Update package.json with API documentation build script

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -12,6 +12,7 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
+    "gen-api-docs": "docusaurus gen-api-docs all",
     "typecheck": "tsc"
   },
   "dependencies": {


### PR DESCRIPTION
The `package.json` file was missing `"gen-api-docs": "docusaurus gen-api-docs all"`