### PR TITLE
docs(fix): Update Hallucination Corrector model example

### DIFF
--- a/www/docs/api-reference/hcm-apis/hallucination-correction-models.md
+++ b/www/docs/api-reference/hcm-apis/hallucination-correction-models.md
@@ -35,10 +35,10 @@ pagination.
 
 ```json
 {
-  "hallucination_correction_models": [
+  "hallucination_correctors": [
     {
       "id": "hc_123",
-      "name": "qwen2.5-7b-instruct-hcm",
+      "name": "vhc-small-1.0",
       "type": "vectara",
       "description": "Qwen/Qwen2.5-7B-Instruct LLM for hallucination correction in AI-generated text.",
       "enabled": true

--- a/www/docs/api-reference/llms-apis/hallucination_correctors.md
+++ b/www/docs/api-reference/llms-apis/hallucination_correctors.md
@@ -49,9 +49,9 @@ The response corrects the original summary.
 
 ```json
 {
-  "original_summary": "The Treaty of Versailles was signed in 1920, officially ending World War I. 
+  "original_text": "The Treaty of Versailles was signed in 1920, officially ending World War I. 
   It was primarily negotiated by France, Britain, Italy, and Japan.",
-  "corrected_summary": "The Treaty of Versailles was signed in 1919, officially ending World War I. 
+  "corrected_text": "The Treaty of Versailles was signed in 1919, officially ending World War I. 
   It was primarily negotiated by France, Britain, Italy, and the United States."
 }
 ```


### PR DESCRIPTION
Updated the hallucination corrector model example to `vhc-small-1.0`