### PR TITLE
Fix MCP broken link in the agents page

### DIFF
--- a/www/docs/agents/agent-platform-overview.md
+++ b/www/docs/agents/agent-platform-overview.md
@@ -65,7 +65,7 @@ Agents act as the orchestration layer of the platform:
 Tools provide agents with capabilities to interact with data and external systems:
 - **Corpora Search**: Query your Vectara corpora with semantic search.
 - **Web Search**: Access current information from the internet.
-- **MCP Tools**: Integrate with external services through the [Model Context Protocol (MCP)](model-context-protocol).
+- **MCP Tools**: Integrate with external services through the [Model Context Protocol (MCP)](mcp).
 
 ### Sessions
 


### PR DESCRIPTION
The link for the `Agents > MCP` page is broken. 

Incorrect link: https://docs.vectara.com/docs/agents/model-context-protocol
The correct link is: https://docs.vectara.com/docs/agents/mcp

<img width="600" height="300" alt="Screenshot 2025-09-22 at 5 09 06 PM" src="https://github.com/user-attachments/assets/7c85b5b4-5ede-45f5-bfac-483149b90aea" />
